### PR TITLE
Minor bug fix, and update to base docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-2-24
+## [Unreleased] - 2021-3-3
 
 ### Added
 
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Fixed a bug related to permissions on the badges directory if it 
+  didn't already exist prior to running the action. Bug only appeared to
+  exhibit itself if the `jacoco-badge-generator` was used in combination with
+  version 3.6 or later of the `peter-evans/create-pull-request` action, and only
+  if the badges directory didn't already exist. This bug is now resolved.
 
 ### CI/CD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### CI/CD
+
+
+## [2.0.1] - 2021-3-3
+
+### Changed
 * Changed the tag used to pull the base docker image from `latest`
   to the specific version number that is the latest. The reason for this change
   is to ensure that we have the opportunity to test against updates to
@@ -16,18 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tag when pulling the base image runs the risk of a change in the base
   image breaking the action (although this risk is small).
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 * Fixed a bug related to permissions on the badges directory if it 
   didn't already exist prior to running the action. Bug only appeared to
   exhibit itself if the `jacoco-badge-generator` was used in combination with
   version 3.6 or later of the `peter-evans/create-pull-request` action, and only
   if the badges directory didn't already exist. This bug is now resolved.
-
-### CI/CD
 
 
 ## [2.0.0] - 2021-2-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Changed the tag used to pull the base docker image from `latest`
+  to the specific version number that is the latest. The reason for this change
+  is to ensure that we have the opportunity to test against updates to
+  the base image before such changes affect releases. Using the `latest`
+  tag when pulling the base image runs the risk of a change in the base
+  image breaking the action (although this risk is small).
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM cicirello/pyaction-lite:latest
+FROM cicirello/pyaction-lite:3.13.2
 COPY JacocoBadgeGenerator.py /JacocoBadgeGenerator.py
 ENTRYPOINT ["/JacocoBadgeGenerator.py"]

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -141,6 +141,7 @@ def createOutputDirectories(badgesDirectory) :
     """
     if not os.path.exists(badgesDirectory) :
         p = pathlib.Path(badgesDirectory)
+        os.umask(0)
         p.mkdir(mode=0o777, parents=True, exist_ok=True)
 
 def splitPath(filenameWithPath) :

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ jobs:
 
     - name: Generate JaCoCo Badge
       id: jacoco
-      uses: cicirello/jacoco-badge-generator@v2.0.0
+      uses: cicirello/jacoco-badge-generator@v2.0.1
 
     - name: Log coverage percentage
       run: |
@@ -296,7 +296,7 @@ jobs:
 
     - name: Generate JaCoCo Badge
       id: jacoco
-      uses: cicirello/jacoco-badge-generator@v2.0.0
+      uses: cicirello/jacoco-badge-generator@v2.0.1
       with:
         generate-branches-badge: true
 


### PR DESCRIPTION
This pull request contains:
* Bug fix related to directory permissions if the badges directory didn't already exist. The bug only showed up in workflows that also used the `peter-evans/create-pull-request` action. This bug is now resolved.
* Switched the tag used to pull base docker image from `latest` to the current specific latest version number, to ensure we have opportunity to test against base image updates before using them.