### PR TITLE
Options for failing workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,22 @@ jobs:
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py
+
+    - name: ONE TIME TEST
+      id: integration3
+      uses: ./
+      with:
+        jacoco-csv-file: tests/jacoco100.csv
+        badges-directory: tests
+        generate-branches-badge: true
+        coverage-badge-filename: 999.svg
+        branches-badge-filename: 999b.svg
+        fail-if-coverage-less-than: 99.9
+        fail-on-coverage-decrease: true
+
+    - name: OUTPUT ONE TIME TEST RESULT
+      run: |
+        echo "COVERAGE BADGE"
+        cat tests/999.svg
+        echo "BRANCHES BADGE"
+        cat tests/999b.svg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,4 +68,4 @@ jobs:
         generate-branches-badge: true
         coverage-badge-filename: 999.svg
         branches-badge-filename: 999b.svg
-        fail-on-branches-decrease: true
+        fail-if-branches-less-than: 99.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
       id: integration3
       uses: ./
       with:
-        jacoco-csv-file: tests/branches100.csv
+        jacoco-csv-file: tests/jacoco100.csv
         badges-directory: tests
         generate-branches-badge: true
         coverage-badge-filename: 999.svg
         branches-badge-filename: 999b.svg
-        fail-if-branches-less-than: 99.9
+        fail-if-coverage-less-than: 99.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,22 +58,3 @@ jobs:
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py
-
-    - name: ONE TIME TEST
-      id: integration3
-      uses: ./
-      with:
-        jacoco-csv-file: tests/jacoco100.csv
-        badges-directory: tests
-        generate-branches-badge: true
-        coverage-badge-filename: 999.svg
-        branches-badge-filename: 999b.svg
-        fail-if-coverage-less-than: 99.9
-        fail-on-coverage-decrease: true
-
-    - name: OUTPUT ONE TIME TEST RESULT
-      run: |
-        echo "COVERAGE BADGE"
-        cat tests/999.svg
-        echo "BRANCHES BADGE"
-        cat tests/999b.svg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
       id: integration3
       uses: ./
       with:
-        jacoco-csv-file: tests/branches90.csv
+        jacoco-csv-file: tests/jacoco90.csv
         badges-directory: tests
         generate-branches-badge: true
-        coverage-badge-filename: jacocoShouldFail.svg
+        coverage-badge-filename: 999.svg
         branches-badge-filename: 999b.svg
-        fail-on-branches-decrease: true
+        fail-on-coverage-decrease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       id: integration3
       uses: ./
       with:
-        jacoco-csv-file: tests/jacoco90.csv
+        jacoco-csv-file: tests/jacoco100.csv
         badges-directory: tests
         generate-branches-badge: true
         coverage-badge-filename: 999.svg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,8 @@ jobs:
       uses: ./
       with:
         jacoco-csv-file: tests/branches90.csv
-        badges-directory: tests/badges
+        badges-directory: tests
         generate-branches-badge: true
         coverage-badge-filename: jacocoShouldFail.svg
-        branches-badge-filename: branchesShouldFail.svg
-        fail-if-branches-less-than: 0.91
+        branches-badge-filename: 999b.svg
+        fail-on-branches-decrease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,14 +58,3 @@ jobs:
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py
-
-    - name: This Should Fail the Workflow
-      id: integration3
-      uses: ./
-      with:
-        jacoco-csv-file: tests/jacoco100.csv
-        badges-directory: tests
-        generate-branches-badge: true
-        coverage-badge-filename: 999.svg
-        branches-badge-filename: 999b.svg
-        fail-if-coverage-less-than: 99.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
       id: integration3
       uses: ./
       with:
-        jacoco-csv-file: tests/jacoco90.csv
+        jacoco-csv-file: tests/branches90.csv
         badges-directory: tests/badges
         generate-branches-badge: true
         coverage-badge-filename: jacocoShouldFail.svg
         branches-badge-filename: branchesShouldFail.svg
-        fail-if-coverage-less-than: "91.1%"
+        fail-if-branches-less-than: 0.91

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
       id: integration3
       uses: ./
       with:
-        jacoco-csv-file: tests/jacoco100.csv
+        jacoco-csv-file: tests/branches100.csv
         badges-directory: tests
         generate-branches-badge: true
         coverage-badge-filename: 999.svg
         branches-badge-filename: 999b.svg
-        fail-on-coverage-decrease: true
+        fail-on-branches-decrease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,14 @@ jobs:
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py
+
+    - name: This Should Fail the Workflow
+      id: integration3
+      uses: ./
+      with:
+        jacoco-csv-file: tests/jacoco90.csv
+        badges-directory: tests/badges
+        generate-branches-badge: true
+        coverage-badge-filename: jacocoShouldFail.svg
+        branches-badge-filename: branchesShouldFail.svg
+        fail-if-coverage-less-than: 91

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,4 +68,4 @@ jobs:
         generate-branches-badge: true
         coverage-badge-filename: jacocoShouldFail.svg
         branches-badge-filename: branchesShouldFail.svg
-        fail-if-coverage-less-than: 91
+        fail-if-coverage-less-than: "91.1%"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A new optional input, `fail-if-branches-less-than`, that 
   enables failing the workflow run if branches coverage is below a 
   user specified minimum.
+* A new optional input, `fail-on-coverage-decrease`, that enables 
+  failing the workflow run if coverage decreased relative to previous run.
+* A new optional input, `fail-on-branches-decrease`, that enables 
+  failing the workflow run if branches coverage decreased relative to previous run.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-5-6
+## [Unreleased] - 2021-5-7
 
 ### Added
+* A new optional input, `fail-if-coverage-less-than`, that 
+  enables failing the workflow run if coverage is below a 
+  user specified minimum.
+* A new optional input, `fail-if-branches-less-than`, that 
+  enables failing the workflow run if branches coverage is below a 
+  user specified minimum.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-5-7
+## [Unreleased] - 2021-5-8
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### CI/CD
+
+
+## [2.2.0] - 2021-5-8
 
 ### Added
 * A new optional input, `fail-if-coverage-less-than`, that 
@@ -18,15 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A new optional input, `fail-on-branches-decrease`, that enables 
   failing the workflow run if branches coverage decreased relative to previous run.
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### CI/CD
 
 
 ## [2.1.2] - 2021-5-6

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -290,6 +290,7 @@ if __name__ == "__main__" :
         cov, branches = computeCoverage(filteredFileList)
 
         if coverageIsFailing(cov, branches, minCoverage, minBranches) :
+            print("Failing the workflow run.")
             sys.exit(1)
 
         if (generateCoverageBadge or generateBranchesBadge) and badgesDirectory != "" :

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -315,17 +315,20 @@ if __name__ == "__main__" :
             print("Failing the workflow run.")
             sys.exit(1)
 
+        coverageBadgeWithPath = formFullPathToFile(badgesDirectory, coverageFilename)
+        branchesBadgeWithPath = formFullPathToFile(badgesDirectory, branchesFilename)
+
         if (generateCoverageBadge or generateBranchesBadge) and badgesDirectory != "" :
             createOutputDirectories(badgesDirectory)
 
         if generateCoverageBadge :
             covStr, color = badgeCoverageStringColorPair(cov)
-            with open(formFullPathToFile(badgesDirectory, coverageFilename), "w") as badge :
+            with open(coverageBadgeWithPath, "w") as badge :
                 badge.write(generateBadge(covStr, color))
 
         if generateBranchesBadge :
             covStr, color = badgeCoverageStringColorPair(branches)
-            with open(formFullPathToFile(badgesDirectory, branchesFilename), "w") as badge :
+            with open(branchesBadgeWithPath, "w") as badge :
                 badge.write(generateBadge(covStr, color, "branches"))
 
         print("::set-output name=coverage::" + str(cov))

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -238,6 +238,26 @@ def stringToPercentage(s) :
         doDivide = True
     return p / 100 if doDivide else p
 
+def coverageIsFailing(coverage, branches, minCoverage, minBranches) :
+    """Checks if coverage or branchs coverage or both are
+    below minimum to pass workflow run. Logs messages if it is.
+    Actual failing behavior should be handled by caller.
+
+    Keyword arguments:
+    coverage - instructions coverage in interval 0.0 to 1.0.
+    branches - branches coverage in interval 0.0 to 1.0.
+    minCoverage - minimum instructions coverage to pass in interval 0.0 to 1.0.
+    minBranches - minimum branches coverage to pass in interval 0.0 to 1.0.
+    """
+    shouldFail = False
+    if coverage < minCoverage :
+        shouldFail = True
+        print("Coverage of", coverage, "is below passing threshold of", minCoverage)
+    if branches < minBranches :
+        shouldFail = True
+        print("Branches of", branches, "is below passing threshold of", minBranches)
+    return shouldFail
+
 if __name__ == "__main__" :
     jacocoCsvFile = sys.argv[1]
     badgesDirectory = sys.argv[2]
@@ -246,6 +266,8 @@ if __name__ == "__main__" :
     generateCoverageBadge = sys.argv[5].lower() == "true"
     generateBranchesBadge = sys.argv[6].lower() == "true"
     onMissingReport = sys.argv[7].lower()
+    minCoverage = stringToPercentage(sys.argv[8])
+    minBranches = stringToPercentage(sys.argv[9])
 
     if onMissingReport not in {"fail", "quiet", "badges"} :
         print("ERROR: Invalid value for on-missing-report.")
@@ -266,6 +288,9 @@ if __name__ == "__main__" :
     if len(filteredFileList) > 0 and (noReportsMissing or onMissingReport!="quiet") :  
 
         cov, branches = computeCoverage(filteredFileList)
+
+        if coverageIsFailing(cov, branches, minCoverage, minBranches) :
+            sys.exit(1)
 
         if (generateCoverageBadge or generateBranchesBadge) and badgesDirectory != "" :
             createOutputDirectories(badgesDirectory)

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -258,6 +258,28 @@ def coverageIsFailing(coverage, branches, minCoverage, minBranches) :
         print("Branches of", branches, "is below passing threshold of", minBranches)
     return shouldFail
 
+def getPriorCoverage(badgeFilename, whichBadge) :
+    """Parses an existing badge (if one exists) returning
+    the coverage percentage stored there. Returns -1 if
+    badge file doesn't exist or if it isn't of the expected format.
+
+    Keyword arguments:
+    badgeFilename - the filename with path
+    whichBadge - this input should be one of 'coverage' or 'branches'
+    """
+    if not os.path.isfile(badgeFilename) :
+        return -1
+    with open(badgeFilename, "r") as f :
+        priorBadge = f.read()
+    i = priorBadge.find(whichBadge)
+    if i < 0 :
+        return -1
+    i += len(whichBadge) + 1
+    j = priorBadge.find("%", i)
+    if j < 0 :
+        return -1
+    return stringToPercentage(priorBadge[i:j+1].strip())
+
 if __name__ == "__main__" :
     jacocoCsvFile = sys.argv[1]
     badgesDirectory = sys.argv[2]

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -290,6 +290,8 @@ if __name__ == "__main__" :
     onMissingReport = sys.argv[7].lower()
     minCoverage = stringToPercentage(sys.argv[8])
     minBranches = stringToPercentage(sys.argv[9])
+    failOnCoverageDecrease = sys.argv[10].lower() == "true"
+    failOnBranchesDecrease = sys.argv[11].lower() == "true"
 
     if onMissingReport not in {"fail", "quiet", "badges"} :
         print("ERROR: Invalid value for on-missing-report.")

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -209,6 +209,35 @@ def filterMissingReports(jacocoFileList, failIfMissing=False) :
         sys.exit(1)
     return goodReports
 
+def stringToPercentage(s) :
+    """Converts a string describing a percentage to
+    a float. The string s can be of any of the following
+    forms: 60.2%, 60.2, or 0.602. All three of these will
+    be treated the same. Without the percent sign, it is
+    treated the same as with the percent sign if the value
+    is greater than 1. This is to gracefully handle
+    user misinterpretation of action input specification. In all cases,
+    this function will return a float in the interval [0.0, 1.0].
+
+    Keyword arguments:
+    s - the string to convert.
+    """
+    if len(s)==0 :
+        return 0
+    doDivide = False
+    if s[-1]=="%" :
+        s = s[:-1].strip()
+        if len(s)==0 :
+            return 0
+        doDivide = True
+    try :
+        p = float(s)
+    except ValueError :
+        return 0
+    if p > 1 :
+        doDivide = True
+    return p / 100 if doDivide else p
+
 if __name__ == "__main__" :
     jacocoCsvFile = sys.argv[1]
     badgesDirectory = sys.argv[2]

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ You can also use a specific release with:
 
 ```yml
     - name: Generate JaCoCo Badge
-      uses: cicirello/jacoco-badge-generator@v2.1.2
+      uses: cicirello/jacoco-badge-generator@v2.2.0
       with:
         generate-branches-badge: true
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ See the [Inputs](#inputs) section for how to change the directory and filenames 
 the badges.  You can of course also link these to the JaCoCo coverage report if you host it
 online, or perhaps to the workflow that generated it, such as with (just replace 
 USERNAME and REPOSITORY with yours):
-```
+```markdown
 [![Coverage](.github/badges/jacoco.svg)](https://github.com/USERNAME/REPOSITORY/actions/workflows/build.yml)
 ```
 The above assumes that the relevant workflow is `build.yml` (replace as needed). This will

--- a/README.md
+++ b/README.md
@@ -244,6 +244,21 @@ For example, all of the following are equivalent: `fail-if-branches-less-than: 0
 Note that in the last case, you need the quotes due to the percent sign.
 Values greater than 1 are assumed percents.
 
+### `fail-on-coverage-decrease`
+
+This input enables directing the action to fail the workflow run if
+the computed coverage is less than it was on the previous run as recorded in the
+existing coverage badge, if one exists. The default is `false`. 
+Use `fail-on-coverage-decrease: true` to enable.
+
+### `fail-on-branches-decrease`
+
+This input enables directing the action to fail the workflow run if
+the computed branches coverage is less than it was on the previous run as recorded in the
+existing branches badge, if one exists. The default is `false`. 
+Use `fail-on-branches-decrease: true` to enable.
+
+
 ## Outputs
 
 The action also outputs the actual computed coverage percentages as double-precision

--- a/README.md
+++ b/README.md
@@ -120,12 +120,16 @@ instead be truncated to 79.9%).
 If you use the action's default badges directory and default badge filenames, then 
 you can add the coverage badge to your repository's readme with the following 
 markdown: `![Coverage](.github/badges/jacoco.svg)`, and likewise for the
-branch coverage badge: `![Coverage](.github/badges/branches.svg)`.
-You can of course also link these to the JaCoCo coverage report if you host it
-online, or perhaps to the workflow that generated it, such as
-with `[![Coverage](.github/badges/jacoco.svg)](URL-TO-WORKFLOW-RUN-GOES-HERE)`.
+branch coverage badge: `![Branches](.github/badges/branches.svg)`.
 See the [Inputs](#inputs) section for how to change the directory and filenames of
-the badges.
+the badges.  You can of course also link these to the JaCoCo coverage report if you host it
+online, or perhaps to the workflow that generated it, such as with (just replace 
+USERNAME and REPOSITORY with yours):
+```
+[![Coverage](.github/badges/jacoco.svg)](https://github.com/USERNAME/REPOSITORY/actions/workflows/build.yml)
+```
+The above assumes that the relevant workflow is `build.yml` (replace as needed). This will
+link the badge to the runs of that specific workflow.
 
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -222,6 +222,27 @@ Regardless of value passed to this input, the action will log warnings for
 any files listed in the `jacoco-csv-file` input that do not exist, for your 
 inspection in the workflow run. 
 
+### `fail-if-coverage-less-than`
+
+This input enables directing the action to fail the workflow run if
+the computed coverage is less than a minimum. The default is 0, effectively
+disabling the option. You can specify it as either a floating point value
+in the interval 0.0 to 1.0, or as a percent (with or without the percent sign).
+For example, all of the following are equivalent: `fail-if-coverage-less-than: 0.6`,
+`fail-if-coverage-less-than: 60`, or `fail-if-coverage-less-than: "60%"`.
+Note that in the last case, you need the quotes due to the percent sign.
+Values greater than 1 are assumed percents.
+
+### `fail-if-branches-less-than`
+
+This input enables directing the action to fail the workflow run if
+the computed branches coverage is less than a minimum. The default is 0, effectively
+disabling the option. You can specify it as either a floating point value
+in the interval 0.0 to 1.0, or as a percent (with or without the percent sign).
+For example, all of the following are equivalent: `fail-if-branches-less-than: 0.6`,
+`fail-if-branches-less-than: 60`, or `fail-if-branches-less-than: "60%"`.
+Note that in the last case, you need the quotes due to the percent sign.
+Values greater than 1 are assumed percents.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,14 @@ inputs:
     description: 'Controls what happens if one or more jacoco.csv files do not exist.'
     required: false
     default: 'fail'
+  fail-if-coverage-less-than:
+    description: 'Enables failing workflow run when coverage below specified threshold.'
+    required: false
+    default: 0
+  fail-if-branches-less-than:
+    description: 'Enables failing workflow run when branches coverage below specified threshold.'
+    required: false
+    default: 0
 outputs:
   coverage:
     description: 'The jacoco coverage percentage as computed from the data in the jacoco.csv file.'
@@ -75,3 +83,5 @@ runs:
     - ${{ inputs.generate-coverage-badge }}
     - ${{ inputs.generate-branches-badge }}
     - ${{ inputs.on-missing-report }}
+    - ${{ inputs.fail-if-coverage-less-than }}
+    - ${{ inputs.fail-if-branches-less-than }}

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,14 @@ inputs:
     description: 'Enables failing workflow run when branches coverage below specified threshold.'
     required: false
     default: 0
+  fail-on-coverage-decrease:
+    description: 'Enables failing workflow if coverage is less than it was on previous run.'
+    required: false
+    default: false
+  fail-on-branches-decrease:
+    description: 'Enables failing workflow if branches coverage is less than it was on previous run.'
+    required: false
+    default: false
 outputs:
   coverage:
     description: 'The jacoco coverage percentage as computed from the data in the jacoco.csv file.'
@@ -85,3 +93,5 @@ runs:
     - ${{ inputs.on-missing-report }}
     - ${{ inputs.fail-if-coverage-less-than }}
     - ${{ inputs.fail-if-branches-less-than }}
+    - ${{ inputs.fail-on-coverage-decrease }}
+    - ${{ inputs.fail-on-branches-decrease }}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,6 +32,43 @@ import JacocoBadgeGenerator as jbg
 
 class TestJacocoBadgeGenerator(unittest.TestCase) :
 
+    def testStringToPercentage(self) :
+        for i in range(0, 101, 10) :
+            expected = i/100
+            s1 = str(i)
+            s2 = s1 + "%"
+            s3 = s1 + " %"
+            s4 = str(expected)
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s1))
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s2))
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s3))
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s4))
+        for j in range(10, 101, 10) :
+            i = j - 0.5
+            expected = i/100
+            s1 = str(i)
+            s2 = s1 + "%"
+            s3 = s1 + " %"
+            s4 = str(expected)
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s1))
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s2))
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s3))
+            self.assertAlmostEqual(expected, jbg.stringToPercentage(s4))
+        i = 0.0
+        while i <= 1.0 :
+            s1 = str(i)
+            self.assertAlmostEqual(i, jbg.stringToPercentage(s1))
+            s2 = s1 + "%"
+            s3 = s1 + " %"
+            self.assertAlmostEqual(i/100, jbg.stringToPercentage(s2))
+            self.assertAlmostEqual(i/100, jbg.stringToPercentage(s3))
+            i += 0.05
+        self.assertAlmostEqual(0, jbg.stringToPercentage(""))
+        self.assertAlmostEqual(0, jbg.stringToPercentage("%"))
+        self.assertAlmostEqual(0, jbg.stringToPercentage(" %"))
+        self.assertAlmostEqual(0, jbg.stringToPercentage(" "))
+        self.assertAlmostEqual(0, jbg.stringToPercentage("hello"))
+
     def testFilterMissingReports_empty(self) :
         self.assertEqual([], jbg.filterMissingReports([]))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,6 +32,14 @@ import JacocoBadgeGenerator as jbg
 
 class TestJacocoBadgeGenerator(unittest.TestCase) :
 
+    def testCoverageIsFailing(self) :
+        self.assertFalse(jbg.coverageIsFailing(0, 0, 0, 0))
+        self.assertFalse(jbg.coverageIsFailing(0.5, 0.5, 0.5, 0.5))
+        self.assertFalse(jbg.coverageIsFailing(0.51, 0.51, 0.5, 0.5))
+        self.assertTrue(jbg.coverageIsFailing(0.49, 0.5, 0.5, 0.5))
+        self.assertTrue(jbg.coverageIsFailing(0.5, 0.49, 0.5, 0.5))
+        self.assertTrue(jbg.coverageIsFailing(0.49, 0.49, 0.5, 0.5))
+
     def testStringToPercentage(self) :
         for i in range(0, 101, 10) :
             expected = i/100

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -57,6 +57,11 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
             self.assertFalse(jbg.coverageDecreased(prior[i]+0.1, f, "branches"))
             self.assertTrue(jbg.coverageDecreased(prior[i]-0.1, f, "branches"))
 
+        for i in range(0, 101, 5) :
+            cov = i / 100
+            self.assertFalse(jbg.coverageDecreased(cov, "tests/idontexist.svg", "coverage"))
+            self.assertFalse(jbg.coverageDecreased(cov, "tests/idontexist.svg", "branches"))
+
     def testGetPriorCoverage(self):
         badgeFiles = [ "tests/0.svg",
                           "tests/599.svg",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,6 +32,31 @@ import JacocoBadgeGenerator as jbg
 
 class TestJacocoBadgeGenerator(unittest.TestCase) :
 
+    def testCoverageDecreased(self) :
+        badgeFiles = [ "tests/0.svg",
+                          "tests/599.svg",
+                          "tests/60.svg",
+                          "tests/70.svg",
+                          "tests/80.svg",
+                          "tests/899.svg",
+                          "tests/90.svg",
+                          "tests/99.svg",
+                          "tests/999.svg",
+                          "tests/100.svg"
+                          ]
+        prior = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1.0 ]
+        for i, f in enumerate(badgeFiles) :
+            self.assertFalse(jbg.coverageDecreased(prior[i], f, "coverage"))
+            self.assertFalse(jbg.coverageDecreased(prior[i]+0.1, f, "coverage"))
+            self.assertTrue(jbg.coverageDecreased(prior[i]-0.1, f, "coverage"))
+
+        branchesBadgeFiles = [ "tests/87b.svg", "tests/90b.svg", "tests/999b.svg" ]
+        prior = [0.87, 0.9, 0.999]
+        for i, f in enumerate(branchesBadgeFiles) :
+            self.assertFalse(jbg.coverageDecreased(prior[i], f, "branches"))
+            self.assertFalse(jbg.coverageDecreased(prior[i]+0.1, f, "branches"))
+            self.assertTrue(jbg.coverageDecreased(prior[i]-0.1, f, "branches"))
+
     def testGetPriorCoverage(self):
         badgeFiles = [ "tests/0.svg",
                           "tests/599.svg",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,6 +32,31 @@ import JacocoBadgeGenerator as jbg
 
 class TestJacocoBadgeGenerator(unittest.TestCase) :
 
+    def testGetPriorCoverage(self):
+        badgeFiles = [ "tests/0.svg",
+                          "tests/599.svg",
+                          "tests/60.svg",
+                          "tests/70.svg",
+                          "tests/80.svg",
+                          "tests/899.svg",
+                          "tests/90.svg",
+                          "tests/99.svg",
+                          "tests/999.svg",
+                          "tests/100.svg"
+                          ]
+        expected = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1.0 ]
+        for i, f in enumerate(badgeFiles) :
+            self.assertAlmostEqual(expected[i], jbg.getPriorCoverage(f, "coverage"))
+        self.assertEqual(-1, jbg.getPriorCoverage("tests/idontexist.svg", "coverage"))
+        self.assertEqual(-1, jbg.getPriorCoverage("tests/999b.svg", "coverage"))
+
+        branchesBadgeFiles = [ "tests/87b.svg", "tests/90b.svg", "tests/999b.svg" ]
+        expected = [0.87, 0.9, 0.999]
+        for i, f in enumerate(branchesBadgeFiles) :
+            self.assertAlmostEqual(expected[i], jbg.getPriorCoverage(f, "branches"))
+        self.assertEqual(-1, jbg.getPriorCoverage("tests/idontexist.svg", "branches"))
+        self.assertEqual(-1, jbg.getPriorCoverage("tests/999.svg", "branches"))
+
     def testCoverageIsFailing(self) :
         self.assertFalse(jbg.coverageIsFailing(0, 0, 0, 0))
         self.assertFalse(jbg.coverageIsFailing(0.5, 0.5, 0.5, 0.5))


### PR DESCRIPTION
## Summary
Added new inputs to enable failing a workflow for coverage decreases and/or if coverage below a threshold.

## Closing Issues
Closes #21 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
