### PR TITLE
Customize color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-5-20
+## [Unreleased] - 2021-6-25
 
 ### Added
 
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+
+
+## [2.3.0] - 2021-6-25
+
+### Added
+* Customization of badge colors, using two new inputs (`colors` and 
+  `intervals`). The defaults for the new inputs produce badges with
+  the existing color scheme.
 
 
 ## [2.2.1] - 2021-5-20

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -56,7 +56,7 @@ textLength="{2}">{0}</text><text x="815" y="140" \
 transform="scale(.1)" fill="#fff" textLength="{2}">{0}</text>\
 </g></svg>'
 
-colors = [ "#4c1", "#97ca00", "#a4a61d", "#dfb317", "#fe7d37", "#e05d44" ]
+defaultColors = [ "#4c1", "#97ca00", "#a4a61d", "#dfb317", "#fe7d37", "#e05d44" ]
 
 def generateBadge(covStr, color, badgeType="coverage") :
     """Generates the badge as a string.
@@ -131,26 +131,30 @@ def coverageTruncatedToString(coverage) :
         covStr = "{0:.1f}%".format(coverage)
     return covStr, coverage
 
-def badgeCoverageStringColorPair(coverage, cutoffs=[100, 90, 80, 70, 60]) :
+def badgeCoverageStringColorPair(coverage, cutoffs=[100, 90, 80, 70, 60], colors=[]) :
     """Converts the coverage percentage to a formatted string,
     and determines the badge color.
     Returns: coveragePercentageAsString, colorAsString
 
     Keyword arguments:
     coverage - The coverage percentage.
+    cutoffs - List of percentages that begin begin each color interval.
+    colors - List of badge colors in decreasing order of coverage percentages.
     """
+    if len(colors) == 0 :
+        colors = defaultColors
     cov, coverage = coverageTruncatedToString(coverage)
-    c = computeColorIndex(coverage, cutoffs)
+    c = computeColorIndex(coverage, cutoffs, len(colors))
     return cov, colors[c]
 
-def computeColorIndex(coverage, cutoffs) :
+def computeColorIndex(coverage, cutoffs, numColors) :
     """Computes index into color list from coverage.
 
     Keyword arguments:
     coverage - The coverage percentage.
     cutoffs - The thresholds for each color.
     """
-    numIntervals = min(len(colors), len(cutoffs)+1)
+    numIntervals = min(numColors, len(cutoffs)+1)
     for c in range(numIntervals-1) :
         if coverage >= cutoffs[c] :
             return c

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -131,7 +131,7 @@ def coverageTruncatedToString(coverage) :
         covStr = "{0:.1f}%".format(coverage)
     return covStr, coverage
 
-def badgeCoverageStringColorPair(coverage) :
+def badgeCoverageStringColorPair(coverage, cutoffs=[100, 90, 80, 70, 60]) :
     """Converts the coverage percentage to a formatted string,
     and determines the badge color.
     Returns: coveragePercentageAsString, colorAsString
@@ -140,10 +140,21 @@ def badgeCoverageStringColorPair(coverage) :
     coverage - The coverage percentage.
     """
     cov, coverage = coverageTruncatedToString(coverage)
-    c = math.ceil((100 - coverage) / 10)
-    if c >= len(colors) :
-        c = len(colors) - 1
+    c = computeColorIndex(coverage, cutoffs)
     return cov, colors[c]
+
+def computeColorIndex(coverage, cutoffs) :
+    """Computes index into color list from coverage.
+
+    Keyword arguments:
+    coverage - The coverage percentage.
+    cutoffs - The thresholds for each color.
+    """
+    numIntervals = min(len(colors), len(cutoffs)+1)
+    for c in range(numIntervals-1) :
+        if coverage >= cutoffs[c] :
+            return c
+    return numIntervals-1
 
 def createOutputDirectories(badgesDirectory) :
     """Creates the output directory if it doesn't already exist.

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -352,6 +352,7 @@ if __name__ == "__main__" :
     failOnCoverageDecrease = sys.argv[10].lower() == "true"
     failOnBranchesDecrease = sys.argv[11].lower() == "true"
     colorCutoffs = colorCutoffsStringToNumberList(sys.argv[12])
+    colors = sys.argv[13].replace(',', ' ').split()
 
     if onMissingReport not in {"fail", "quiet", "badges"} :
         print("ERROR: Invalid value for on-missing-report.")
@@ -392,12 +393,12 @@ if __name__ == "__main__" :
             createOutputDirectories(badgesDirectory)
 
         if generateCoverageBadge :
-            covStr, color = badgeCoverageStringColorPair(cov, colorCutoffs)
+            covStr, color = badgeCoverageStringColorPair(cov, colorCutoffs, colors)
             with open(coverageBadgeWithPath, "w") as badge :
                 badge.write(generateBadge(covStr, color))
 
         if generateBranchesBadge :
-            covStr, color = badgeCoverageStringColorPair(branches, colorCutoffs)
+            covStr, color = badgeCoverageStringColorPair(branches, colorCutoffs, colors)
             with open(branchesBadgeWithPath, "w") as badge :
                 badge.write(generateBadge(covStr, color, "branches"))
 

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -326,6 +326,15 @@ def coverageDecreased(coverage, badgeFilename, whichBadge) :
         return True
     return False
 
+def colorCutoffsStringToNumberList(strCutoffs) :
+    """Converts a string of space or comma separated percentages
+    to a list of floats.
+
+    Keyword arguments:
+    strCutoffs - a string of space or comma separated percentages
+    """
+    return list(map(float, strCutoffs.replace(',', ' ').split()))
+
 if __name__ == "__main__" :
     jacocoCsvFile = sys.argv[1]
     badgesDirectory = sys.argv[2]
@@ -338,6 +347,7 @@ if __name__ == "__main__" :
     minBranches = stringToPercentage(sys.argv[9])
     failOnCoverageDecrease = sys.argv[10].lower() == "true"
     failOnBranchesDecrease = sys.argv[11].lower() == "true"
+    colorCutoffs = colorCutoffsStringToNumberList(sys.argv[12])
 
     if onMissingReport not in {"fail", "quiet", "badges"} :
         print("ERROR: Invalid value for on-missing-report.")
@@ -378,12 +388,12 @@ if __name__ == "__main__" :
             createOutputDirectories(badgesDirectory)
 
         if generateCoverageBadge :
-            covStr, color = badgeCoverageStringColorPair(cov)
+            covStr, color = badgeCoverageStringColorPair(cov, colorCutoffs)
             with open(coverageBadgeWithPath, "w") as badge :
                 badge.write(generateBadge(covStr, color))
 
         if generateBranchesBadge :
-            covStr, color = badgeCoverageStringColorPair(branches)
+            covStr, color = badgeCoverageStringColorPair(branches, colorCutoffs)
             with open(branchesBadgeWithPath, "w") as badge :
                 badge.write(generateBadge(covStr, color, "branches"))
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ quotes around the input if none of the colors are specified by hex.
 Although the default uses six colors and six coverage intervals, you can have
 as many or as few as you want. For example, if you want to use `green` regardless
 of percentage, you can set colors like this: `colors: green`. If you pass more
-colors than there are intervals, then the extra colors will be ignored.
+colors than there are intervals, then the extra colors will be ignored. If you 
+pass an empty list of colors, then the action will simply use the default colors.
+__The action does not do any validation of the colors that you pass.__
 
 ### `intervals`
 

--- a/README.md
+++ b/README.md
@@ -209,42 +209,42 @@ created within the `badges-directory`
 directory. __The action doesn't commit the badge file. You will 
 need to have additional steps in your workflow to do that.__
 
-### `color-intervals`
+### `intervals`
 
 This input enables specifying the coverage intervals for the 
 different colors. It is a simple list of percentages. The default
-is `color-intervals: 100 90 80 70 60 0`, which corresponds to what is
+is `intervals: 100 90 80 70 60 0`, which corresponds to what is
 described in the section [Badge Style and Content](#badge-style-and-content)
 above.  That is, coverage of 100 percent is bright green, 90 or higher is
 green, 80 or higher is yellow green, and so forth. The action assumes that
 the percentages in this list are in decreasing order, and the behavior of the action
 is not defined if you violate that assumption. You can space separate or
-comma separate the percentages. For example, `color-intervals: 100 90 80 70 60 0`
-is equivalent to `color-intervals: 100, 90, 80, 70, 60, 0`. A mix of spaces and commas
+comma separate the percentages. For example, `intervals: 100 90 80 70 60 0`
+is equivalent to `intervals: 100, 90, 80, 70, 60, 0`. A mix of spaces and commas
 will also work.
 
 If you specify too many intervals, the extras will simply be ignored. The action
 uses a total of 6 colors. Only the first 5 percentages specified in this input
 are used, with the sixth color designated for coverages that are below that last
-cutoff.  For example, `color-intervals: 100 90 80 70 60` is equivalent to
-`color-intervals: 100 90 80 70 60 0`.
+cutoff.  For example, `intervals: 100 90 80 70 60` is equivalent to
+`intervals: 100 90 80 70 60 0`.
 
 Although these examples have integer percentages, the action supports floating-point
 values. For example, you can specify something 
-like `color-intervals: 99.5 90 80 70 60`.
+like `intervals: 99.5 90 80 70 60`.
 
 If you only want to use the first three colors (bright green, green, and yellow green),
-then you can use something like `color-intervals: 80 60`, which will assign
+then you can use something like `intervals: 80 60`, which will assign
 80 and above to bright green, 60 and above to green, and less than 60 to yellow
 green.
 
 If you want to skip colors, you can exploit the action's assumption of decreasing
 colors. For example, if you want to use bright green for 80 and above, 
 yellow for 60 and above, and red for less than 60, you might do something like the
-following: `color-intervals: 80 101 101 60 101 0`. The 101s in this example
+following: `intervals: 80 101 101 60 101 0`. The 101s in this example
 essentially disable the corresponding colors, and in fact any values in those
 spots inconsistent with the decreasing order will work as well, such as
-`color-intervals: 80 80 80 60 60 0`.  The 0 at the end is optional.  
+`intervals: 80 80 80 60 60 0`.  The 0 at the end is optional.  
 
 ### `on-missing-report`
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,14 @@ of C1 Coverage than is usually implied by branches coverage.
 ## Badge Style and Content
 
 The badges that are generated are inspired by the style of the badges 
-of [Shields.io](https://github.com/badges/shields), however, the badges are entirely generated
-within the jacoco-badge-generator GitHub Action, with no external calls.  Here are
-a few samples of what the badges look like:
+of [Shields.io](https://github.com/badges/shields), however, 
+the badges are entirely generated within the jacoco-badge-generator 
+GitHub Action, with no external calls.  
+
+### Default Color Scheme
+
+Here are a few samples of what the badges look like if you use
+the default colors:
 * ![Coverage 100%](tests/100.svg) We use bright green for 100% coverage.
 * ![Coverage 99.9%](tests/999.svg) We use green for coverage from 90% up through 99.9%.
 * ![Coverage 80%](tests/80.svg) We use yellow green for coverage from 80% up through 89.9%.
@@ -118,6 +123,19 @@ a few samples of what the badges look like:
 * ![Coverage 59.9%](tests/599.svg) We use red for coverage from 0% up through 59.9%.
 * ![Branches Coverage 99.9%](tests/999b.svg) A sample of a branch coverage badge.
 
+### Customizing Colors or Coverage Intervals
+
+The jacoco-badge-generator action provides two inputs that can be used
+to customize the colors used for the badges. The `colors` input enables you to
+pass a list of colors to the action. The `intervals` input enables you to pass
+a list of percentages used to determine color choice. If you like the default
+colors, but want to start the colors at different percentages, then you can use
+the `intervals` input to accomplish that. These two inputs can be used either
+individually or in combination depending upon what you want to do. See the
+[Inputs](#inputs) section for more details.
+
+### Displayed Percentages
+
 The coverage displayed in the badge is the result of truncating to one 
 decimal place.  If that decimal place is 0, then it is displayed as an 
 integer.  The rationale for truncating to one decimal place, rather than 
@@ -125,6 +143,8 @@ rounding is to avoid displaying a just failing coverage as passing. For
 example, if the user of the action considers 80% to be a passing level,
 then we wish to avoid the case of 79.9999% being rounded to 80% (it will
 instead be truncated to 79.9%). 
+
+### Adding the Badges to your README
 
 If you use the action's default badges directory and default badge filenames, then 
 you can add the coverage badge to your repository's readme with the following 
@@ -209,42 +229,63 @@ created within the `badges-directory`
 directory. __The action doesn't commit the badge file. You will 
 need to have additional steps in your workflow to do that.__
 
+### `colors`
+
+This input can be used to change the colors used for the badges.
+It defaults to `colors: '#4c1 #97ca00 #a4a61d #dfb317 #fe7d37 #e05d44'`,
+which are the hex color codes for the colors described previously in 
+section [Default Color Scheme](#default-color-scheme).
+Because `#` has special meaning to YAML (it is used for comments), you 
+must either put quotes around the input value as shown in this example, or
+you can escape each `#`. The list of colors that you pass here can either
+be space separated (as shown) or comma separated. The colors in this list
+can be specified either with hex (as in the example above), or with any
+named colors that are recognized by SVG, or some combination of the two.
+Here is an example with named 
+colors: `colors: green yellow orange red purple blue`. Notice that you don't need
+quotes around the input if none of the colors are specified by hex.
+Although the default uses six colors and six coverage intervals, you can have
+as many or as few as you want. For example, if you want to use `green` regardless
+of percentage, you can set colors like this: `colors: green`. If you pass more
+colors than there are intervals, then the extra colors will be ignored.
+
 ### `intervals`
 
 This input enables specifying the coverage intervals for the 
 different colors. It is a simple list of percentages. The default
 is `intervals: 100 90 80 70 60 0`, which corresponds to what is
-described in the section [Badge Style and Content](#badge-style-and-content)
-above.  That is, coverage of 100 percent is bright green, 90 or higher is
-green, 80 or higher is yellow green, and so forth. The action assumes that
-the percentages in this list are in decreasing order, and the behavior of the action
-is not defined if you violate that assumption. You can space separate or
+described in the section [Default Color Scheme](#default-color-scheme)
+earlier.  The action assumes that the percentages in this list are in 
+decreasing order. You can space separate or
 comma separate the percentages. For example, `intervals: 100 90 80 70 60 0`
 is equivalent to `intervals: 100, 90, 80, 70, 60, 0`. A mix of spaces and commas
 will also work.
 
-If you specify too many intervals, the extras will simply be ignored. The action
-uses a total of 6 colors. Only the first 5 percentages specified in this input
-are used, with the sixth color designated for coverages that are below that last
-cutoff.  For example, `intervals: 100 90 80 70 60` is equivalent to
-`intervals: 100 90 80 70 60 0`.
+If you specify too many intervals, the extras will simply be ignored. If there
+are C colors altogether, then only the first (C-1) percentages specified in 
+this input are used, with the last color designated for coverages that are below 
+that last cutoff.  For example, if you use the default set of 6 colors, then
+`intervals: 100 90 80 70 60` is equivalent to `intervals: 100 90 80 70 60 0`.
 
-Although these examples have integer percentages, the action supports floating-point
-values. For example, you can specify something 
+Although these examples have integer percentages, the action 
+supports floating-point values. For example, you can specify something 
 like `intervals: 99.5 90 80 70 60`.
 
-If you only want to use the first three colors (bright green, green, and yellow green),
+If you only want to use the first three default colors (bright green, green, 
+and yellow green), then you don't necessarily need to change the value
+of the `colors` input. You can keep the default colors, and
 then you can use something like `intervals: 80 60`, which will assign
 80 and above to bright green, 60 and above to green, and less than 60 to yellow
 green.
 
-If you want to skip colors, you can exploit the action's assumption of decreasing
-colors. For example, if you want to use bright green for 80 and above, 
+If you like some of the default colors, but want to skip over some of them,
+then you can either use a combination of the `colors` input and `intervals`
+input to accomplish this, or you can leave `colors` at the default and
+exploit the action's assumption of decreasing percentages in the `intervals`
+input to skip the ones you don't like. For example, if 
+you want to use bright green for 80 and above, 
 yellow for 60 and above, and red for less than 60, you might do something like the
-following: `intervals: 80 101 101 60 101 0`. The 101s in this example
-essentially disable the corresponding colors, and in fact any values in those
-spots inconsistent with the decreasing order will work as well, such as
-`intervals: 80 80 80 60 60 0`.  The 0 at the end is optional.  
+following: `intervals: 80 80 80 60 60 0`. The 0 at the end is optional.  
 
 ### `on-missing-report`
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,43 @@ created within the `badges-directory`
 directory. __The action doesn't commit the badge file. You will 
 need to have additional steps in your workflow to do that.__
 
+### `color-intervals`
+
+This input enables specifying the coverage intervals for the 
+different colors. It is a simple list of percentages. The default
+is `color-intervals: 100 90 80 70 60 0`, which corresponds to what is
+described in the section [Badge Style and Content](#badge-style-and-content)
+above.  That is, coverage of 100 percent is bright green, 90 or higher is
+green, 80 or higher is yellow green, and so forth. The action assumes that
+the percentages in this list are in decreasing order, and the behavior of the action
+is not defined if you violate that assumption. You can space separate or
+comma separate the percentages. For example, `color-intervals: 100 90 80 70 60 0`
+is equivalent to `color-intervals: 100, 90, 80, 70, 60, 0`. A mix of spaces and commas
+will also work.
+
+If you specify too many intervals, the extras will simply be ignored. The action
+uses a total of 6 colors. Only the first 5 percentages specified in this input
+are used, with the sixth color designated for coverages that are below that last
+cutoff.  For example, `color-intervals: 100 90 80 70 60` is equivalent to
+`color-intervals: 100 90 80 70 60 0`.
+
+Although these examples have integer percentages, the action supports floating-point
+values. For example, you can specify something 
+like `color-intervals: 99.5 90 80 70 60`.
+
+If you only want to use the first three colors (bright green, green, and yellow green),
+then you can use something like `color-intervals: 80 60`, which will assign
+80 and above to bright green, 60 and above to green, and less than 60 to yellow
+green.
+
+If you want to skip colors, you can exploit the action's assumption of decreasing
+colors. For example, if you want to use bright green for 80 and above, 
+yellow for 60 and above, and red for less than 60, you might do something like the
+following: `color-intervals: 80 101 101 60 101 0`. The 101s in this example
+essentially disable the corresponding colors, and in fact any values in those
+spots inconsistent with the decreasing order will work as well, such as
+`color-intervals: 80 80 80 60 60 0`.  The 0 at the end is optional.  
+
 ### `on-missing-report`
 
 This input controls what happens if one or more `jacoco.csv` files do not exist.

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ inputs:
     description: 'Enables failing workflow if branches coverage is less than it was on previous run.'
     required: false
     default: false
-  color-intervals:
+  intervals:
     description: 'List of coverage percentages as cutoffs for each color.'
     required: false
     default: 100 90 80 70 60 0
@@ -99,4 +99,4 @@ runs:
     - ${{ inputs.fail-if-branches-less-than }}
     - ${{ inputs.fail-on-coverage-decrease }}
     - ${{ inputs.fail-on-branches-decrease }}
-    - ${{ inputs.color-intervals }}
+    - ${{ inputs.intervals }}

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,10 @@ inputs:
     description: 'Enables failing workflow if branches coverage is less than it was on previous run.'
     required: false
     default: false
+  color-intervals:
+    description: 'List of coverage percentages as cutoffs for each color.'
+    required: false
+    default: 100 90 80 70 60 0
 outputs:
   coverage:
     description: 'The jacoco coverage percentage as computed from the data in the jacoco.csv file.'
@@ -95,3 +99,4 @@ runs:
     - ${{ inputs.fail-if-branches-less-than }}
     - ${{ inputs.fail-on-coverage-decrease }}
     - ${{ inputs.fail-on-branches-decrease }}
+    - ${{ inputs.color-intervals }}

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: 'List of coverage percentages as cutoffs for each color.'
     required: false
     default: 100 90 80 70 60 0
+  colors:
+    description: 'List of colors to use ordered by coverage interval, best coverage to worst.'
+    required: false
+    default: '#4c1 #97ca00 #a4a61d #dfb317 #fe7d37 #e05d44'
 outputs:
   coverage:
     description: 'The jacoco coverage percentage as computed from the data in the jacoco.csv file.'
@@ -100,3 +104,4 @@ runs:
     - ${{ inputs.fail-on-coverage-decrease }}
     - ${{ inputs.fail-on-branches-decrease }}
     - ${{ inputs.intervals }}
+    - ${{ inputs.colors }}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -223,6 +223,85 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         self.assertEqual(jbg.colors[5], jbg.badgeCoverageStringColorPair(0.0)[1])
         self.assertEqual(jbg.colors[5], jbg.badgeCoverageStringColorPair(0)[1])
 
+    def testColorIndex(self):
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60]));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60]));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60]));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60]));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60]));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60]));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60]));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60]));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60]));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60]));
+        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60]));
+        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60]));
+        # more cutoffs than necessary
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50]));
+        # even more cutoffs than necessary
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50, 0]));
+        # too few cutoffs
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70]));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70]));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70]));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70]));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70]));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70]));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70]));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70]));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70]));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70]));
+        self.assertEquals(4, jbg.computeColorIndex(59.999, [100, 90, 80, 70]));
+        self.assertEquals(4, jbg.computeColorIndex(50, [100, 90, 80, 70]));
+        # only 1 cutoff
+        self.assertEquals(0, jbg.computeColorIndex(100, [100]));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(89.999, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(80, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(79.999, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(70, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(69.999, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(60, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(59.999, [100]));
+        self.assertEquals(1, jbg.computeColorIndex(50, [100]));
+        # no cutoffs
+        self.assertEquals(0, jbg.computeColorIndex(100, []));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, []));
+        self.assertEquals(0, jbg.computeColorIndex(99.999, []));
+        self.assertEquals(0, jbg.computeColorIndex(90, []));
+        self.assertEquals(0, jbg.computeColorIndex(89.999, []));
+        self.assertEquals(0, jbg.computeColorIndex(80, []));
+        self.assertEquals(0, jbg.computeColorIndex(79.999, []));
+        self.assertEquals(0, jbg.computeColorIndex(70, []));
+        self.assertEquals(0, jbg.computeColorIndex(69.999, []));
+        self.assertEquals(0, jbg.computeColorIndex(60, []));
+        self.assertEquals(0, jbg.computeColorIndex(59.999, []));
+        self.assertEquals(0, jbg.computeColorIndex(50, []));
+        
     def testBadgeGeneration(self) :
         testPercentages = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1]
         expectedFiles = [ "tests/0.svg",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -209,98 +209,162 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         self.assertEqual("99.1%", jbg.badgeCoverageStringColorPair(0.991000001)[0])
 
     def testColor(self) :
-        self.assertEqual(jbg.colors[0], jbg.badgeCoverageStringColorPair(1)[1])
-        self.assertEqual(jbg.colors[0], jbg.badgeCoverageStringColorPair(1.0)[1])
-        self.assertEqual(jbg.colors[1], jbg.badgeCoverageStringColorPair(0.99999)[1])
-        self.assertEqual(jbg.colors[1], jbg.badgeCoverageStringColorPair(0.9)[1])
-        self.assertEqual(jbg.colors[2], jbg.badgeCoverageStringColorPair(0.89999)[1])
-        self.assertEqual(jbg.colors[2], jbg.badgeCoverageStringColorPair(0.8)[1])
-        self.assertEqual(jbg.colors[3], jbg.badgeCoverageStringColorPair(0.79999)[1])
-        self.assertEqual(jbg.colors[3], jbg.badgeCoverageStringColorPair(0.7)[1])
-        self.assertEqual(jbg.colors[4], jbg.badgeCoverageStringColorPair(0.69999)[1])
-        self.assertEqual(jbg.colors[4], jbg.badgeCoverageStringColorPair(0.6)[1])
-        self.assertEqual(jbg.colors[5], jbg.badgeCoverageStringColorPair(0.59999)[1])
-        self.assertEqual(jbg.colors[5], jbg.badgeCoverageStringColorPair(0.0)[1])
-        self.assertEqual(jbg.colors[5], jbg.badgeCoverageStringColorPair(0)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1.0)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.99999)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.9)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.89999)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.8)[1])
+        self.assertEqual(jbg.defaultColors[3], jbg.badgeCoverageStringColorPair(0.79999)[1])
+        self.assertEqual(jbg.defaultColors[3], jbg.badgeCoverageStringColorPair(0.7)[1])
+        self.assertEqual(jbg.defaultColors[4], jbg.badgeCoverageStringColorPair(0.69999)[1])
+        self.assertEqual(jbg.defaultColors[4], jbg.badgeCoverageStringColorPair(0.6)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0.59999)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0.0)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0)[1])
+        # extra colors
+        colors = jbg.defaultColors[:]
+        colors.append("#000000")
+        colors.append("#ffffff")
+        cutoffs=[100, 90, 80, 70, 60]
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.99999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.9, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.89999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.8, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[3], jbg.badgeCoverageStringColorPair(0.79999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[3], jbg.badgeCoverageStringColorPair(0.7, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[4], jbg.badgeCoverageStringColorPair(0.69999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[4], jbg.badgeCoverageStringColorPair(0.6, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0.59999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0, cutoffs, colors)[1])
+        # fewer colors
+        colors = jbg.defaultColors[:3]
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.99999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.9, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.89999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.8, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.79999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.7, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.69999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.6, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.59999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0, cutoffs, colors)[1])
+        # only 1 color
+        colors = jbg.defaultColors[:1]
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.99999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.9, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.89999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.8, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.79999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.7, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.69999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.6, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.59999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(0, cutoffs, colors)[1])
+        # empty color list should use default.
+        colors = []
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[0], jbg.badgeCoverageStringColorPair(1.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.99999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[1], jbg.badgeCoverageStringColorPair(0.9, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.89999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[2], jbg.badgeCoverageStringColorPair(0.8, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[3], jbg.badgeCoverageStringColorPair(0.79999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[3], jbg.badgeCoverageStringColorPair(0.7, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[4], jbg.badgeCoverageStringColorPair(0.69999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[4], jbg.badgeCoverageStringColorPair(0.6, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0.59999, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0.0, cutoffs, colors)[1])
+        self.assertEqual(jbg.defaultColors[5], jbg.badgeCoverageStringColorPair(0, cutoffs, colors)[1])
+        
 
     def testColorIndex(self):
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60]));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60]));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60]));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60]));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60]));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60]));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60]));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60]));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60]));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60]));
-        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60]));
-        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60]));
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60], 6));
+        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60], 6));
         # more cutoffs than necessary
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50]));
-        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50]));
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50], 6));
         # even more cutoffs than necessary
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50, 0]));
-        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50, 0]));
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50, 0], 6));
         # too few cutoffs
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70]));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70]));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70]));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70]));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70]));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70]));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70]));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70]));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70]));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70]));
-        self.assertEquals(4, jbg.computeColorIndex(59.999, [100, 90, 80, 70]));
-        self.assertEquals(4, jbg.computeColorIndex(50, [100, 90, 80, 70]));
+        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70], 6));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70], 6));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70], 6));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70], 6));
+        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70], 6));
+        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70], 6));
+        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70], 6));
+        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70], 6));
+        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70], 6));
+        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70], 6));
+        self.assertEquals(4, jbg.computeColorIndex(59.999, [100, 90, 80, 70], 6));
+        self.assertEquals(4, jbg.computeColorIndex(50, [100, 90, 80, 70], 6));
         # only 1 cutoff
-        self.assertEquals(0, jbg.computeColorIndex(100, [100]));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(89.999, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(80, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(79.999, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(70, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(69.999, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(60, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(59.999, [100]));
-        self.assertEquals(1, jbg.computeColorIndex(50, [100]));
+        self.assertEquals(0, jbg.computeColorIndex(100, [100], 6));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(99.999, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(90, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(89.999, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(80, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(79.999, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(70, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(69.999, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(60, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(59.999, [100], 6));
+        self.assertEquals(1, jbg.computeColorIndex(50, [100], 6));
         # no cutoffs
-        self.assertEquals(0, jbg.computeColorIndex(100, []));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, []));
-        self.assertEquals(0, jbg.computeColorIndex(99.999, []));
-        self.assertEquals(0, jbg.computeColorIndex(90, []));
-        self.assertEquals(0, jbg.computeColorIndex(89.999, []));
-        self.assertEquals(0, jbg.computeColorIndex(80, []));
-        self.assertEquals(0, jbg.computeColorIndex(79.999, []));
-        self.assertEquals(0, jbg.computeColorIndex(70, []));
-        self.assertEquals(0, jbg.computeColorIndex(69.999, []));
-        self.assertEquals(0, jbg.computeColorIndex(60, []));
-        self.assertEquals(0, jbg.computeColorIndex(59.999, []));
-        self.assertEquals(0, jbg.computeColorIndex(50, []));
+        self.assertEquals(0, jbg.computeColorIndex(100, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(100.0, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(99.999, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(90, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(89.999, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(80, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(79.999, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(70, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(69.999, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(60, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(59.999, [], 6));
+        self.assertEquals(0, jbg.computeColorIndex(50, [], 6));
         
     def testBadgeGeneration(self) :
         testPercentages = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -288,83 +288,83 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         
 
     def testColorIndex(self):
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60], 6));
-        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60], 6));
+        self.assertEqual(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60], 6));
         # more cutoffs than necessary
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50], 6));
-        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50], 6));
+        self.assertEqual(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50], 6));
         # even more cutoffs than necessary
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50, 0], 6));
-        self.assertEquals(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(1, jbg.computeColorIndex(90, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(2, jbg.computeColorIndex(80, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(3, jbg.computeColorIndex(70, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(4, jbg.computeColorIndex(60, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(5, jbg.computeColorIndex(59.999, [100, 90, 80, 70, 60, 50, 0], 6));
+        self.assertEqual(5, jbg.computeColorIndex(50, [100, 90, 80, 70, 60, 50, 0], 6));
         # too few cutoffs
-        self.assertEquals(0, jbg.computeColorIndex(100, [100, 90, 80, 70], 6));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70], 6));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70], 6));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100, 90, 80, 70], 6));
-        self.assertEquals(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70], 6));
-        self.assertEquals(2, jbg.computeColorIndex(80, [100, 90, 80, 70], 6));
-        self.assertEquals(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70], 6));
-        self.assertEquals(3, jbg.computeColorIndex(70, [100, 90, 80, 70], 6));
-        self.assertEquals(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70], 6));
-        self.assertEquals(4, jbg.computeColorIndex(60, [100, 90, 80, 70], 6));
-        self.assertEquals(4, jbg.computeColorIndex(59.999, [100, 90, 80, 70], 6));
-        self.assertEquals(4, jbg.computeColorIndex(50, [100, 90, 80, 70], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100, [100, 90, 80, 70], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100.0, [100, 90, 80, 70], 6));
+        self.assertEqual(1, jbg.computeColorIndex(99.999, [100, 90, 80, 70], 6));
+        self.assertEqual(1, jbg.computeColorIndex(90, [100, 90, 80, 70], 6));
+        self.assertEqual(2, jbg.computeColorIndex(89.999, [100, 90, 80, 70], 6));
+        self.assertEqual(2, jbg.computeColorIndex(80, [100, 90, 80, 70], 6));
+        self.assertEqual(3, jbg.computeColorIndex(79.999, [100, 90, 80, 70], 6));
+        self.assertEqual(3, jbg.computeColorIndex(70, [100, 90, 80, 70], 6));
+        self.assertEqual(4, jbg.computeColorIndex(69.999, [100, 90, 80, 70], 6));
+        self.assertEqual(4, jbg.computeColorIndex(60, [100, 90, 80, 70], 6));
+        self.assertEqual(4, jbg.computeColorIndex(59.999, [100, 90, 80, 70], 6));
+        self.assertEqual(4, jbg.computeColorIndex(50, [100, 90, 80, 70], 6));
         # only 1 cutoff
-        self.assertEquals(0, jbg.computeColorIndex(100, [100], 6));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(99.999, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(90, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(89.999, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(80, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(79.999, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(70, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(69.999, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(60, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(59.999, [100], 6));
-        self.assertEquals(1, jbg.computeColorIndex(50, [100], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100, [100], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100.0, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(99.999, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(90, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(89.999, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(80, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(79.999, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(70, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(69.999, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(60, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(59.999, [100], 6));
+        self.assertEqual(1, jbg.computeColorIndex(50, [100], 6));
         # no cutoffs
-        self.assertEquals(0, jbg.computeColorIndex(100, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(100.0, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(99.999, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(90, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(89.999, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(80, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(79.999, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(70, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(69.999, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(60, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(59.999, [], 6));
-        self.assertEquals(0, jbg.computeColorIndex(50, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(100.0, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(99.999, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(90, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(89.999, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(80, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(79.999, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(70, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(69.999, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(60, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(59.999, [], 6));
+        self.assertEqual(0, jbg.computeColorIndex(50, [], 6));
         
     def testBadgeGeneration(self) :
         testPercentages = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1]
@@ -446,8 +446,8 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         self.assertEqual([100, 90, 80, 70, 60, 0], jbg.colorCutoffsStringToNumberList('100, 90, 80, 70, 60, 0'))
         self.assertEqual([100, 90, 80, 70, 60, 0], jbg.colorCutoffsStringToNumberList('100 90 80 70 60 0'))
         self.assertEqual([100, 90, 80, 70, 60, 0], jbg.colorCutoffsStringToNumberList('100,90,80,70,60,0'))
-        self.assertEquals([], jbg.colorCutoffsStringToNumberList(''))
-        self.assertEquals([], jbg.colorCutoffsStringToNumberList(','))
-        self.assertEquals([], jbg.colorCutoffsStringToNumberList('   '))
-        self.assertEquals([99.9], jbg.colorCutoffsStringToNumberList('99.9'))
-        self.assertEquals([99.9], jbg.colorCutoffsStringToNumberList('99.9,'))
+        self.assertEqual([], jbg.colorCutoffsStringToNumberList(''))
+        self.assertEqual([], jbg.colorCutoffsStringToNumberList(','))
+        self.assertEqual([], jbg.colorCutoffsStringToNumberList('   '))
+        self.assertEqual([99.9], jbg.colorCutoffsStringToNumberList('99.9'))
+        self.assertEqual([99.9], jbg.colorCutoffsStringToNumberList('99.9,'))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -378,5 +378,12 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         for directory, filename, expected in cases :
             self.assertEqual(expected, jbg.formFullPathToFile(directory, filename))
             
-                  
-                          
+    def testStringToFloatCutoffs(self) :
+        self.assertEqual([100, 90, 80, 70, 60, 0], jbg.colorCutoffsStringToNumberList('100, 90, 80, 70, 60, 0'))
+        self.assertEqual([100, 90, 80, 70, 60, 0], jbg.colorCutoffsStringToNumberList('100 90 80 70 60 0'))
+        self.assertEqual([100, 90, 80, 70, 60, 0], jbg.colorCutoffsStringToNumberList('100,90,80,70,60,0'))
+        self.assertEquals([], jbg.colorCutoffsStringToNumberList(''))
+        self.assertEquals([], jbg.colorCutoffsStringToNumberList(','))
+        self.assertEquals([], jbg.colorCutoffsStringToNumberList('   '))
+        self.assertEquals([99.9], jbg.colorCutoffsStringToNumberList('99.9'))
+        self.assertEquals([99.9], jbg.colorCutoffsStringToNumberList('99.9,'))


### PR DESCRIPTION
## Summary
Added two inputs to enable users to customize the color scheme, such as the coverage intervals and colors used for each interval.

## Closing Issues
Closes #30 
Closes #31 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
