### PR TITLE
Added option to generate JSON Shields endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,5 +56,21 @@ jobs:
         echo "coverage = ${{ steps.integration2.outputs.coverage }}"
         echo "branch coverage = ${{ steps.integration2.outputs.branches }}"
 
+    - name: Integration endpoints test 
+      id: integration3
+      uses: ./
+      with:
+        jacoco-csv-file: tests/jacoco.csv
+        badges-directory: tests/endpoints
+        generate-coverage-badge: false
+        generate-branches-badge: false
+        generate-coverage-endpoint: true
+        generate-branches-endpoint: true
+
+    - name: Log integration endpoints test outputs
+      run: |
+        echo "coverage = ${{ steps.integration3.outputs.coverage }}"
+        echo "branch coverage = ${{ steps.integration3.outputs.branches }}"
+
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2021-08-12
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### CI/CD
+
+
+## [2.4.0] - 2021-08-13
+
+### Added
 * Added an option to generate Shields.io JSON endpoints either in addition to, 
   or instead of, directly generating badges. For most users, the existing direct 
   generation of the badges is probably the preferred approach (e.g., probably 
@@ -19,16 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `coverage-endpoint-filename`, and `branches-endpoint-filename`. All of these 
   have default values and are optional. The current default behavior is retained, 
   so by default the JSON endpoints are not generated.
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### CI/CD
 
 
 ## [2.3.0] - 2021-6-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-6-25
+## [Unreleased] - 2021-08-12
 
 ### Added
+* Added an option to generate Shields.io JSON endpoints either in addition to, 
+  or instead of, directly generating badges. For most users, the existing direct 
+  generation of the badges is probably the preferred approach (e.g., probably 
+  faster serving when loading README, and much simpler insertion of badge into 
+  README). But for those who use one of Shields styles other than the default, 
+  and who would like to be able to match the coverage badges to the style of 
+  their project's other badges, then providing the ability to generate a 
+  Shields JSON endpoint gives them the ability to do so. The new feature is 
+  controlled by 4 new inputs: `generate-coverage-endpoint`, `generate-branches-endpoint`, 
+  `coverage-endpoint-filename`, and `branches-endpoint-filename`. All of these 
+  have default values and are optional. The current default behavior is retained, 
+  so by default the JSON endpoints are not generated.
 
 ### Changed
 

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# jacoco-badge-generator: Github action for generating a jacoco coverage
-# percentage badge.
+# jacoco-badge-generator: Coverage badges, and pull request coverage checks,
+# from JaCoCo reports in GitHub Actions.
 # 
 # Copyright (c) 2020-2021 Vincent A Cicirello
 # https://www.cicirello.org/
@@ -73,6 +73,22 @@ def generateBadge(covStr, color, badgeType="coverage") :
     else :
         textLength = "170"
     return badgeTemplate.format(covStr, color, textLength, badgeType)
+
+def generateDictionaryForEndpoint(covStr, color, badgeType) :
+    """Generated a Python dictionary containing all of the required
+    fields for a Shields.io JSON endpoint.
+
+    Keyword arguments:
+    covStr - The coverage as a string.
+    color - The color for the badge.
+    badgeType - The text string for a label on the badge.
+    """
+    return {
+        "schemaVersion" : 1,
+        "label" : badgeType,
+        "message" : covStr,
+        "color" : color
+        }
 
 def computeCoverage(fileList) :
     """Parses one or more jacoco.csv files and computes code coverage

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -450,6 +450,8 @@ if __name__ == "__main__" :
 
         coverageBadgeWithPath = formFullPathToFile(badgesDirectory, coverageFilename)
         branchesBadgeWithPath = formFullPathToFile(badgesDirectory, branchesFilename)
+        coverageJSONWithPath = formFullPathToFile(badgesDirectory, coverageJSON)
+        branchesJSONWithPath = formFullPathToFile(badgesDirectory, branchesJSON)
 
         if failOnCoverageDecrease and generateCoverageBadge and coverageDecreased(cov, coverageBadgeWithPath, "coverage") :
             print("Failing the workflow run.")
@@ -459,18 +461,34 @@ if __name__ == "__main__" :
             print("Failing the workflow run.")
             sys.exit(1)
 
-        if (generateCoverageBadge or generateBranchesBadge) and badgesDirectory != "" :
+        if failOnCoverageDecrease and generateCoverageJSON and coverageDecreasedEndpoint(cov, coverageJSONWithPath, "coverage") :
+            print("Failing the workflow run.")
+            sys.exit(1)
+
+        if failOnBranchesDecrease and generateBranchesJSON and coverageDecreasedEndpoint(branches, branchesJSONWithPath, "branches") :
+            print("Failing the workflow run.")
+            sys.exit(1)
+            
+        if (generateCoverageBadge or generateBranchesBadge or generateCoverageJSON or generateBranchesJSON) and badgesDirectory != "" :
             createOutputDirectories(badgesDirectory)
 
-        if generateCoverageBadge :
+        if generateCoverageBadge or generateCoverageJSON :
             covStr, color = badgeCoverageStringColorPair(cov, colorCutoffs, colors)
-            with open(coverageBadgeWithPath, "w") as badge :
-                badge.write(generateBadge(covStr, color))
+            if generateCoverageBadge :
+                with open(coverageBadgeWithPath, "w") as badge :
+                    badge.write(generateBadge(covStr, color))
+            if generateCoverageJSON :
+                with open(coverageJSONWithPath, "w") as endpoint :
+                    json.dump(generateDictionaryForEndpoint(covStr, color, "coverage"), endpoint, sort_keys=True)
 
-        if generateBranchesBadge :
+        if generateBranchesBadge or generateBranchesJSON :
             covStr, color = badgeCoverageStringColorPair(branches, colorCutoffs, colors)
-            with open(branchesBadgeWithPath, "w") as badge :
-                badge.write(generateBadge(covStr, color, "branches"))
+            if generateBranchesBadge :
+                with open(branchesBadgeWithPath, "w") as badge :
+                    badge.write(generateBadge(covStr, color, "branches"))
+            if generateBranchesJSON :
+                with open(branchesJSONWithPath, "w") as endpoint :
+                    json.dump(generateDictionaryForEndpoint(covStr, color, "branches"), endpoint, sort_keys=True)
 
         print("::set-output name=coverage::" + str(cov))
         print("::set-output name=branches::" + str(branches))

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -33,6 +33,7 @@ import math
 import pathlib
 import os
 import os.path
+import json
 
 badgeTemplate = '<svg xmlns="http://www.w3.org/2000/svg" width="104" \
 height="20" role="img" aria-label="{3}: {0}">\
@@ -320,6 +321,25 @@ def getPriorCoverage(badgeFilename, whichBadge) :
     if j < 0 :
         return -1
     return stringToPercentage(priorBadge[i:j+1].strip())
+
+def getPriorCoverageFromEndpoint(jsonFilename) :
+    """Parses an existing JSON endpoint (if one exists) returning
+    the coverage percentage stored there. Returns -1 if
+    file doesn't exist or if it isn't of the expected format.
+
+    Keyword arguments:
+    jsonFilename - the filename with path
+    """
+    if not os.path.isfile(jsonFilename) :
+        return -1
+    try :
+        with open(jsonFilename, "r") as f :
+            priorEndpoint = json.load(f)
+    except :
+        return -1
+    if "message" not in priorEndpoint :
+        return -1
+    return stringToPercentage(priorEndpoint["message"].strip())
 
 def coverageDecreased(coverage, badgeFilename, whichBadge) :
     """Checks if coverage decreased relative to previous run, and logs

--- a/JacocoBadgeGenerator.py
+++ b/JacocoBadgeGenerator.py
@@ -419,6 +419,10 @@ if __name__ == "__main__" :
     failOnBranchesDecrease = sys.argv[11].lower() == "true"
     colorCutoffs = colorCutoffsStringToNumberList(sys.argv[12])
     colors = sys.argv[13].replace(',', ' ').split()
+    generateCoverageJSON = sys.argv[14].lower() == "true"
+    generateBranchesJSON = sys.argv[15].lower() == "true"
+    coverageJSON = sys.argv[16]
+    branchesJSON = sys.argv[17]
 
     if onMissingReport not in {"fail", "quiet", "badges"} :
         print("ERROR: Invalid value for on-missing-report.")

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ something similar for the branches coverage badge, such as:
 ```markdown
 ![Branches](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FUSERNAME%2FREPOSITORY%2FBRANCHNAME%2F.github%2Fbadges%2Fbranches.json)
 ```
+And of course, you can also link these to your workflow runs just as before with:
+```markdown
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FUSERNAME%2FREPOSITORY%2FBRANCHNAME%2F.github%2Fbadges%2Fjacoco.json)](https://github.com/USERNAME/REPOSITORY/actions/workflows/build.yml)
+```
 
 If you do have reason to prefer generating endpoints over generating the badges directly,
 then you might consider pushing the endpoints to a GitHub Pages site instead, such
@@ -214,7 +218,8 @@ branch. To do so, in addition to configuring GitHub Pages, you would need to use
 `badges-directory` input to change the directory where the endpoints are stored
 (e.g., in "docs" or in a subdirectory of "docs"). Doing so would probably speed up Shields's
 access to your JSON endpoint, since you'd gain the benefit of the CDN that backs GitHub
-Pages; whereas passing Shields the URL to the JSON file on GitHub's raw server would not.
+Pages; whereas passing Shields the URL to the JSON file on GitHub's raw server will probably
+be slower.
 
 This is not an issue if you use the default behavior of directly generating the badge.
 

--- a/README.md
+++ b/README.md
@@ -598,6 +598,10 @@ what these inputs do.
         coverage-badge-filename: jacoco.svg
         generate-branches-badge: false
         branches-badge-filename: branches.svg
+        generate-coverage-endpoint: false
+        coverage-endpoint-filename: jacoco.json
+        generate-branches-endpoint: false
+        branches-endpoint-filename: branches.json
         colors: '#4c1 #97ca00 #a4a61d #dfb317 #fe7d37 #e05d44'
         intervals: 100 90 80 70 60 0
         on-missing-report: fail

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Check out all of our GitHub Actions: https://actions.cicirello.org/
 The jacoco-badge-generator GitHub Action parses a `jacoco.csv` from a JaCoCo coverage report,
 computes coverage percentages from [JaCoCo's Instructions and Branches counters](https://www.jacoco.org/jacoco/trunk/doc/counters.html), and 
 generates badges for one or both of these (configurable with action inputs) to provide an easy 
-to read visual summary of the code coverage of your test cases. The action supports
+to read visual summary of the code coverage of your test cases. The default behavior directly
+generates the badges internally with no external calls, but the action also provides an option
+to instead generate [Shields JSON endpoints](https://shields.io/endpoint). The action supports
 both the basic case of a single `jacoco.csv`, as well as multi-module projects in which
 case the action can produce coverage badges from the combination of the JaCoCo reports
 from all modules, provided that the individual reports are independent.
@@ -113,11 +115,6 @@ of C1 Coverage than is usually implied by branches coverage.
 
 ## Badge Style and Content
 
-The badges that are generated are inspired by the style of the badges 
-of [Shields.io](https://github.com/badges/shields), however, 
-the badges are entirely generated within the jacoco-badge-generator 
-GitHub Action, with no external calls.  
-
 ### Default Color Scheme
 
 Here are a few samples of what the badges look like if you use
@@ -151,14 +148,39 @@ example, if the user of the action considers 80% to be a passing level,
 then we wish to avoid the case of 79.9999% being rounded to 80% (it will
 instead be truncated to 79.9%). 
 
+### Direct Badge Generation vs JSON Endpoint
+
+The default behavior generates badges that are inspired by the style of the badges 
+of [Shields.io](https://github.com/badges/shields), and generates the badges entirely
+within the jacoco-badge-generator GitHub Action, with no external calls.  
+However, the action now also supports an optional alternative to instead generate
+[Shields JSON endpoints](https://shields.io/endpoint). Most users will likely prefer
+the default behavior, for a variety of reasons, such as simpler insertion of
+badge into README and probable faster loading. The main reason to consider generating
+a JSON endpoint instead is if you are trying to match the style of the coverage badges
+to other badges in your README that use one of Shields's alternative styles. The default 
+internally generated badges match the default Shields style.
+See the [Inputs](#inputs) section for more details on how to generate JSON endpoints 
+instead of badges.
+
 ### Adding the Badges to your README
+
+#### If you generate the badges (default behavior)....
 
 If you use the action's default badges directory and default badge filenames, then 
 you can add the coverage badge to your repository's readme with the following 
-markdown: `![Coverage](.github/badges/jacoco.svg)`, and likewise for the
-branch coverage badge: `![Branches](.github/badges/branches.svg)`.
+markdown: 
+```markdown
+![Coverage](.github/badges/jacoco.svg)
+```
+
+And likewise for the branch coverage badge: 
+```markdown
+![Branches](.github/badges/branches.svg)
+```
+
 See the [Inputs](#inputs) section for how to change the directory and filenames of
-the badges.  You can of course also link these to the JaCoCo coverage report if you host it
+the badges. You can of course also link these to the JaCoCo coverage report if you host it
 online, or perhaps to the workflow that generated it, such as with (just replace 
 USERNAME and REPOSITORY with yours):
 ```markdown
@@ -166,6 +188,9 @@ USERNAME and REPOSITORY with yours):
 ```
 The above assumes that the relevant workflow is `build.yml` (replace as needed). This will
 link the badge to the runs of that specific workflow.
+
+#### If you generate JSON endpoints instead....
+
 
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -297,10 +297,28 @@ need to have additional steps in your workflow to do that.__
 This input controls whether or not to generate a JSON endpoint 
 for coverage (Instructions Coverage), and defaults to `false`.
 
+### `coverage-endpoint-filename`
+
+This input is the filename for the coverage endpoint (Instructions or C0 
+Coverage) if you have opted to generate a JSON endpoint instead of the
+badge. The default filename is `jacoco.json`, and will be 
+created within the `badges-directory`
+directory. __The action doesn't commit the JSON file. You will 
+need to have additional steps in your workflow to do that.__
+
 ### `generate-branches-endpoint`
 
 This input controls whether or not to generate a JSON endpoint 
 for branches coverage, and defaults to `false`.
+
+### `branches-endpoint-filename`
+
+This input is the filename for the branches coverage endpoint (C1 
+Coverage) if you have opted to generate a JSON endpoint instead of the
+badge. The default filename is `branches.json`, and will be 
+created within the `badges-directory`
+directory. __The action doesn't commit the JSON file. You will 
+need to have additional steps in your workflow to do that.__
 
 ### `colors`
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ created within the `badges-directory`
 directory. __The action doesn't commit the badge file. You will 
 need to have additional steps in your workflow to do that.__
 
+### `generate-coverage-endpoint`
+
+This input controls whether or not to generate a JSON endpoint 
+for coverage (Instructions Coverage), and defaults to `false`.
+
+### `generate-branches-endpoint`
+
+This input controls whether or not to generate a JSON endpoint 
+for branches coverage, and defaults to `false`.
+
 ### `colors`
 
 This input can be used to change the colors used for the badges.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ computes coverage percentages from [JaCoCo's Instructions and Branches counters]
 generates badges for one or both of these (configurable with action inputs) to provide an easy 
 to read visual summary of the code coverage of your test cases. The default behavior directly
 generates the badges internally with no external calls, but the action also provides an option
-to instead generate [Shields JSON endpoints](https://shields.io/endpoint). The action supports
+to instead generate [Shields JSON endpoints](#direct-badge-generation-vs-json-endpoint). The action supports
 both the basic case of a single `jacoco.csv`, as well as multi-module projects in which
 case the action can produce coverage badges from the combination of the JaCoCo reports
 from all modules, provided that the individual reports are independent.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,32 @@ link the badge to the runs of that specific workflow.
 
 #### If you generate JSON endpoints instead....
 
+Inserting coverage badges into your README is more complex if you use
+the alternate behavior of generating JSON endpoints. It involves
+passing the URL of your coverage endpoint to Shields custom badge endpoint.
+Assuming that you use the default badge directory, you would then use
+the following markdown:
+```markdown
+![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FUSERNAME%2FREPOSITORY%2FBRANCHNAME%2F.github%2Fbadges%2Fjacoco.json)
+```
+In the above, replace USERNAME, REPOSITORY, and BRANCHNAME with yours, and it is also important that
+you keep all of the URL encodings of colons `%3A` and backslashes `%2F`. This is necessary because we 
+are passing a URL as a parameter to the Shields badge endpoint. You can do
+something similar for the branches coverage badge, such as:
+```markdown
+![Branches](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FUSERNAME%2FREPOSITORY%2FBRANCHNAME%2F.github%2Fbadges%2Fbranches.json)
+```
+
+If you do have reason to prefer generating endpoints over generating the badges directly,
+then you might consider pushing the endpoints to a GitHub Pages site instead, such
+as a project site served from a docs directory of your default branch, or from a gh-pages
+branch. To do so, in addition to configuring GitHub Pages, you would need to use the
+`badges-directory` input to change the directory where the endpoints are stored
+(e.g., in "docs" or in a subdirectory of "docs"). Doing so would probably speed up Shields's
+access to your JSON endpoint, since you'd gain the benefit of the CDN that backs GitHub
+Pages; whereas passing Shields the URL to the JSON file on GitHub's raw server would not.
+
+This is not an issue if you use the default behavior of directly generating the badge.
 
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,22 @@ inputs:
     description: 'List of colors to use ordered by coverage interval, best coverage to worst.'
     required: false
     default: '#4c1 #97ca00 #a4a61d #dfb317 #fe7d37 #e05d44'
+  generate-coverage-endpoint:
+    description: 'Controls whether or not to generate the coverage JSON endpoint.'
+    required: false
+    default: false
+  generate-branches-endpoint:
+    description: 'Controls whether or not to generate the branches coverage JSON endpoint.'
+    required: false
+    default: false
+  coverage-endpoint-filename:
+    description: 'The filename of the coverage JSON endpoint.'
+    required: false
+    default: 'jacoco.json'
+  branches-endpoint-filename:
+    description: 'The filename of the branches coverage JSON endpoint.'
+    required: false
+    default: 'branches.json'
 outputs:
   coverage:
     description: 'The jacoco coverage percentage as computed from the data in the jacoco.csv file.'
@@ -106,3 +122,7 @@ runs:
     - ${{ inputs.fail-on-branches-decrease }}
     - ${{ inputs.intervals }}
     - ${{ inputs.colors }}
+    - ${{ inputs.generate-coverage-endpoint }}
+    - ${{ inputs.generate-branches-endpoint }}
+    - ${{ inputs.coverage-endpoint-filename }}
+    - ${{ inputs.branches-endpoint-filename }}

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
-# jacoco-badge-generator: Github action for generating a jacoco coverage percentage badge
+# jacoco-badge-generator: Coverage badges, and pull request coverage checks, 
+# from JaCoCo reports in GitHub Actions
 # 
 # Copyright (c) 2020-2021 Vincent A Cicirello
 # https://www.cicirello.org/

--- a/tests/0.json
+++ b/tests/0.json
@@ -1,0 +1,1 @@
+{"color": "#e05d44", "label": "coverage", "message": "0%", "schemaVersion": 1}

--- a/tests/0b.json
+++ b/tests/0b.json
@@ -1,0 +1,1 @@
+{"color": "#e05d44", "label": "branches", "message": "0%", "schemaVersion": 1}

--- a/tests/100.json
+++ b/tests/100.json
@@ -1,0 +1,1 @@
+{"color": "#4c1", "label": "coverage", "message": "100%", "schemaVersion": 1}

--- a/tests/100b.json
+++ b/tests/100b.json
@@ -1,0 +1,1 @@
+{"color": "#4c1", "label": "branches", "message": "100%", "schemaVersion": 1}

--- a/tests/599.json
+++ b/tests/599.json
@@ -1,0 +1,1 @@
+{"color": "#e05d44", "label": "coverage", "message": "59.9%", "schemaVersion": 1}

--- a/tests/599b.json
+++ b/tests/599b.json
@@ -1,0 +1,1 @@
+{"color": "#e05d44", "label": "branches", "message": "59.9%", "schemaVersion": 1}

--- a/tests/60.json
+++ b/tests/60.json
@@ -1,0 +1,1 @@
+{"color": "#fe7d37", "label": "coverage", "message": "60%", "schemaVersion": 1}

--- a/tests/60b.json
+++ b/tests/60b.json
@@ -1,0 +1,1 @@
+{"color": "#fe7d37", "label": "branches", "message": "60%", "schemaVersion": 1}

--- a/tests/70.json
+++ b/tests/70.json
@@ -1,0 +1,1 @@
+{"color": "#dfb317", "label": "coverage", "message": "70%", "schemaVersion": 1}

--- a/tests/70b.json
+++ b/tests/70b.json
@@ -1,0 +1,1 @@
+{"color": "#dfb317", "label": "branches", "message": "70%", "schemaVersion": 1}

--- a/tests/78.json
+++ b/tests/78.json
@@ -1,0 +1,1 @@
+{"color": "#dfb317", "label": "coverage", "message": "78%", "schemaVersion": 1}

--- a/tests/78b.json
+++ b/tests/78b.json
@@ -1,0 +1,1 @@
+{"color": "#dfb317", "label": "branches", "message": "78%", "schemaVersion": 1}

--- a/tests/80.json
+++ b/tests/80.json
@@ -1,0 +1,1 @@
+{"color": "#a4a61d", "label": "coverage", "message": "80%", "schemaVersion": 1}

--- a/tests/80b.json
+++ b/tests/80b.json
@@ -1,0 +1,1 @@
+{"color": "#a4a61d", "label": "branches", "message": "80%", "schemaVersion": 1}

--- a/tests/87.json
+++ b/tests/87.json
@@ -1,0 +1,1 @@
+{"color": "#a4a61d", "label": "coverage", "message": "87%", "schemaVersion": 1}

--- a/tests/87b.json
+++ b/tests/87b.json
@@ -1,0 +1,1 @@
+{"color": "#a4a61d", "label": "branches", "message": "87%", "schemaVersion": 1}

--- a/tests/899.json
+++ b/tests/899.json
@@ -1,0 +1,1 @@
+{"color": "#a4a61d", "label": "coverage", "message": "89.9%", "schemaVersion": 1}

--- a/tests/899b.json
+++ b/tests/899b.json
@@ -1,0 +1,1 @@
+{"color": "#a4a61d", "label": "branches", "message": "89.9%", "schemaVersion": 1}

--- a/tests/90.json
+++ b/tests/90.json
@@ -1,0 +1,1 @@
+{"color": "#97ca00", "label": "coverage", "message": "90%", "schemaVersion": 1}

--- a/tests/90b.json
+++ b/tests/90b.json
@@ -1,0 +1,1 @@
+{"color": "#97ca00", "label": "branches", "message": "90%", "schemaVersion": 1}

--- a/tests/99.json
+++ b/tests/99.json
@@ -1,0 +1,1 @@
+{"color": "#97ca00", "label": "coverage", "message": "99%", "schemaVersion": 1}

--- a/tests/999.json
+++ b/tests/999.json
@@ -1,0 +1,1 @@
+{"color": "#97ca00", "label": "coverage", "message": "99.9%", "schemaVersion": 1}

--- a/tests/999b.json
+++ b/tests/999b.json
@@ -1,0 +1,1 @@
+{"color": "#97ca00", "label": "branches", "message": "99.9%", "schemaVersion": 1}

--- a/tests/99b.json
+++ b/tests/99b.json
@@ -1,0 +1,1 @@
+{"color": "#97ca00", "label": "branches", "message": "99%", "schemaVersion": 1}

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # jacoco-badge-generator: Github action for generating a jacoco coverage
 # percentage badge.
 # 
@@ -28,6 +26,8 @@
 #
 
 import unittest
+import json
+import JacocoBadgeGenerator as jbg
 
 class IntegrationTest(unittest.TestCase) :
 
@@ -49,4 +49,19 @@ class IntegrationTest(unittest.TestCase) :
             with open("tests/badges/branchesMulti.svg","r") as generated :
                 self.assertEqual(expected.read(), generated.read())
 
+    def testIntegrationInstructionsJSON(self) :
+        with open("tests/endpoints/jacoco.json", "r") as f :
+            d = json.load(f)
+            self.assertEqual(1, d["schemaVersion"])
+            self.assertEqual("coverage", d["label"])
+            self.assertEqual("100%", d["message"])
+            self.assertEqual(jbg.defaultColors[0], d["color"])
+
+    def testIntegrationBranchesJSON(self) :
+        with open("tests/endpoints/branches.json", "r") as f :
+            d = json.load(f)
+            self.assertEqual(1, d["schemaVersion"])
+            self.assertEqual("branches", d["label"])
+            self.assertEqual("90%", d["message"])
+            self.assertEqual(jbg.defaultColors[1], d["color"])
     

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -389,6 +389,34 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         with open("tests/999b.svg","r") as f :
             self.assertEqual(f.read(), badge)
 
+    def testGenerateDictionaryForEndpoint(self) :
+        testPercentages = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1]
+        expectedMsg = ["0%", "59.9%", "60%", "70%", "80%", "89.9%", "90%", "99%", "99.9%", "100%"]
+        expectedColor = [
+            jbg.defaultColors[5],
+            jbg.defaultColors[5],
+            jbg.defaultColors[4],
+            jbg.defaultColors[3],
+            jbg.defaultColors[2],
+            jbg.defaultColors[2],
+            jbg.defaultColors[1],
+            jbg.defaultColors[1],
+            jbg.defaultColors[1],
+            jbg.defaultColors[0]
+            ]
+        for i, cov in enumerate(testPercentages) :
+            covStr, color = jbg.badgeCoverageStringColorPair(cov)
+            d = jbg.generateDictionaryForEndpoint(covStr, color, "coverage")
+            self.assertEqual(1, d["schemaVersion"])
+            self.assertEqual("coverage", d["label"])
+            self.assertEqual(expectedMsg[i], d["message"])
+            self.assertEqual(expectedColor[i], d["color"])
+            d = jbg.generateDictionaryForEndpoint(covStr, color, "branches")
+            self.assertEqual(1, d["schemaVersion"])
+            self.assertEqual("branches", d["label"])
+            self.assertEqual(expectedMsg[i], d["message"])
+            self.assertEqual(expectedColor[i], d["color"])
+
     def testSplitPath(self) :
         cases = [ ( "./jacoco.svg", ".", "jacoco.svg" ),
                   ( "/jacoco.svg", ".", "jacoco.svg" ),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -66,6 +66,49 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
             self.assertFalse(jbg.coverageDecreased(cov, "tests/idontexist.svg", "coverage"))
             self.assertFalse(jbg.coverageDecreased(cov, "tests/idontexist.svg", "branches"))
 
+    def testCoverageDecreasedEndpoint(self) :
+        jsonFiles = [ "tests/0.json",
+                          "tests/599.json",
+                          "tests/60.json",
+                          "tests/70.json",
+                          "tests/80.json",
+                          "tests/899.json",
+                          "tests/90.json",
+                          "tests/99.json",
+                          "tests/999.json",
+                          "tests/100.json"
+                          ]
+        prior = [0, 0.599, 0.6, 0.7, 0.8, 0.899, 0.9, 0.99, 0.999, 1.0 ]
+        for i, f in enumerate(jsonFiles) :
+            self.assertFalse(jbg.coverageDecreasedEndpoint(prior[i], f, "coverage"))
+            self.assertFalse(jbg.coverageDecreasedEndpoint(prior[i]+0.1, f, "coverage"))
+            self.assertTrue(jbg.coverageDecreasedEndpoint(prior[i]-0.1, f, "coverage"))
+            self.assertFalse(jbg.coverageDecreasedEndpoint(prior[i]+0.0001, f, "coverage"))
+            self.assertTrue(jbg.coverageDecreasedEndpoint(prior[i]-0.0001, f, "coverage"))
+
+        branchesJsonFiles = [ "tests/0b.json",
+                          "tests/599b.json",
+                          "tests/60b.json",
+                          "tests/70b.json",
+                          "tests/80b.json",
+                          "tests/899b.json",
+                          "tests/90b.json",
+                          "tests/99b.json",
+                          "tests/999b.json",
+                          "tests/100b.json"
+                          ]
+        for i, f in enumerate(branchesJsonFiles) :
+            self.assertFalse(jbg.coverageDecreasedEndpoint(prior[i], f, "branches"))
+            self.assertFalse(jbg.coverageDecreasedEndpoint(prior[i]+0.1, f, "branches"))
+            self.assertTrue(jbg.coverageDecreasedEndpoint(prior[i]-0.1, f, "branches"))
+            self.assertFalse(jbg.coverageDecreasedEndpoint(prior[i]+0.0001, f, "branches"))
+            self.assertTrue(jbg.coverageDecreasedEndpoint(prior[i]-0.0001, f, "branches"))
+
+        for i in range(0, 101, 5) :
+            cov = i / 100
+            self.assertFalse(jbg.coverageDecreasedEndpoint(cov, "tests/idontexist.svg", "coverage"))
+            self.assertFalse(jbg.coverageDecreasedEndpoint(cov, "tests/idontexist.svg", "branches"))
+
     def testGetPriorCoverage(self):
         badgeFiles = [ "tests/0.svg",
                           "tests/599.svg",
@@ -124,9 +167,9 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
             ]
         expected = [0, 0.599, 0.6, 0.7, 0.78, 0.8, 0.87, 0.899, 0.9, 0.99, 0.999, 1.0, -1 ]
         for i, f in enumerate(jsonFiles) :
-            self.assertAlmostEqual(expected[i], jbg.getPriorCoverageFromEndpoint(f), msg="file:"+f)
+            self.assertAlmostEqual(expected[i], jbg.getPriorCoverageFromEndpoint(f, "coverage"), msg="file:"+f)
         for i, f in enumerate(jsonFilesB) :
-            self.assertAlmostEqual(expected[i], jbg.getPriorCoverageFromEndpoint(f), msg="file:"+f)
+            self.assertAlmostEqual(expected[i], jbg.getPriorCoverageFromEndpoint(f, "branches"), msg="file:"+f)
 
     def testCoverageIsFailing(self) :
         self.assertFalse(jbg.coverageIsFailing(0, 0, 0, 0))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -91,6 +91,43 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         self.assertEqual(-1, jbg.getPriorCoverage("tests/idontexist.svg", "branches"))
         self.assertEqual(-1, jbg.getPriorCoverage("tests/999.svg", "branches"))
 
+    def testGetPriorCoverageFromEndpoint(self):
+        jsonFiles = [
+            "tests/0.json",
+            "tests/599.json",
+            "tests/60.json",
+            "tests/70.json",
+            "tests/78.json",
+            "tests/80.json",
+            "tests/87.json",
+            "tests/899.json",
+            "tests/90.json",
+            "tests/99.json",
+            "tests/999.json",
+            "tests/100.json",
+            "tests/idontexist.json"
+            ]
+        jsonFilesB = [
+            "tests/0b.json",
+            "tests/599b.json",
+            "tests/60b.json",
+            "tests/70b.json",
+            "tests/78b.json",
+            "tests/80b.json",
+            "tests/87b.json",
+            "tests/899b.json",
+            "tests/90b.json",
+            "tests/99b.json",
+            "tests/999b.json",
+            "tests/100b.json",
+            "tests/idontexist.json"
+            ]
+        expected = [0, 0.599, 0.6, 0.7, 0.78, 0.8, 0.87, 0.899, 0.9, 0.99, 0.999, 1.0, -1 ]
+        for i, f in enumerate(jsonFiles) :
+            self.assertAlmostEqual(expected[i], jbg.getPriorCoverageFromEndpoint(f), msg="file:"+f)
+        for i, f in enumerate(jsonFilesB) :
+            self.assertAlmostEqual(expected[i], jbg.getPriorCoverageFromEndpoint(f), msg="file:"+f)
+
     def testCoverageIsFailing(self) :
         self.assertFalse(jbg.coverageIsFailing(0, 0, 0, 0))
         self.assertFalse(jbg.coverageIsFailing(0.5, 0.5, 0.5, 0.5))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # jacoco-badge-generator: Github action for generating a jacoco coverage
 # percentage badge.
 # 


### PR DESCRIPTION
## Summary
Added an option to generate Shields.io JSON endpoints either in addition to, or instead of, directly generating badges. For most users, the existing direct generation of the badges is probably the preferred approach (e.g., probably faster serving when loading readme, and much simpler insertion of badge into readme). But for those who use one of Shields styles other than the default, and who would like to be able to match the coverage badges to the style of their project's other badges, then providing the ability to generate a Shields JSON endpoint gives them the ability to do so.

New feature is controlled by 4 new inputs (2 booleans to control whether to generate the JSON coverage endpoint and the JSON branches coverage endpoint, and 2 for the filenames).  All of these have default values and are optional.  The current default behavior is retained, so by default the JSON endpoints are not generated.

## Closing Issues
Closes #35 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
