### PR TITLE
Added alternate entry point for running as CLI utility outside of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,12 @@ jobs:
         echo "coverage = ${{ steps.integration5.outputs.coverage }}"
         echo "branch coverage = ${{ steps.integration5.outputs.branches }}"
 
+    - name: Integration test of CLI use-case
+      id: integrationCLI
+      run: |
+        export PYTHONPATH=$PYTHONPATH:$PWD/src
+        echo $PYTHONPATH
+
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badges --generate-branches-badge true
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/multi1.csv tests/multi2.csv --badges-directory tests/cli/badges --generate-branches-badge true --coverage-badge-filename coverageMulti.svg --branches-badge-filename branchesMulti.svg
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badgesJSON --generate-coverage-badge false --generate-coverage-endpoint true --generate-branches-endpoint true
+        python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/summaryReportTest.csv --badges-directory tests/cli/summary --generate-coverage-badge false --generate-summary true
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         coverage-label: custom coverage label one
         branches-label: custom coverage label two
 
-    - name: Log integration test outputs with a single jacoco.csv
+    - name: Log integration test outputs with custom labels
       run: |
         echo "coverage = ${{ steps.integration5.outputs.coverage }}"
         echo "branch coverage = ${{ steps.integration5.outputs.branches }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/multi1.csv tests/multi2.csv --badges-directory tests/cli/badges --generate-branches-badge true --coverage-badge-filename coverageMulti.svg --branches-badge-filename branchesMulti.svg
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badgesJSON --generate-coverage-badge false --generate-coverage-endpoint true --generate-branches-endpoint true
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/summaryReportTest.csv --badges-directory tests/cli/summary --generate-coverage-badge false --generate-summary true
+        python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badges --generate-branches-badge true --generate-coverage-endpoint true --generate-branches-endpoint true --coverage-badge-filename customCoverage.svg --branches-badge-filename customBranches.svg --coverage-endpoint-filename customCoverage.json --branches-endpoint-filename customBranches.json --coverage-label "custom coverage label one" --branches-label "custom coverage label two"
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
         echo $PYTHONPATH
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badges --generate-branches-badge true
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/multi1.csv tests/multi2.csv --badges-directory tests/cli/badges --generate-branches-badge true --coverage-badge-filename coverageMulti.svg --branches-badge-filename branchesMulti.svg
+        python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badgesJSON --generate-coverage-badge false --generate-coverage-endpoint true --generate-branches-endpoint true
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,10 @@ jobs:
     - name: Integration test of CLI use-case
       id: integrationCLI
       run: |
-        export PYTHONPATH=$PYTHONPATH:$PWD/src
+        export PYTHONPATH=$PWD/src
         echo $PYTHONPATH
+        python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badges --generate-branches-badge true
+        python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/multi1.csv tests/multi2.csv --badges-directory tests/cli/badges --generate-branches-badge true --coverage-badge-filename coverageMulti.svg --branches-badge-filename branchesMulti.svg
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-06-24
+## [Unreleased] - 2022-06-25
 
 ### Added
+* Ability to run as a command-line utility outside of GitHub Actions, such as part of a local build script, etc.
 
 ### Changed
 * Refactored main control block to improve maintainability and ease planned future functionality (#63).

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -33,6 +33,14 @@ from jacoco_badge_generator.coverage_badges import colorCutoffsStringToNumberLis
 import sys
 
 if __name__ == "__main__" :
+    # IMPORTANT: This is the entrypoint for the GitHub Action only.
+    #
+    # This is the entry point when using the
+    # jacoco-badge-generator as a GitHub Action
+    # (its primary use-case). The source code for the entry
+    # point for use locally as a command-line utility is found
+    # at src/jacoco_badge_generator/__main__.py,
+    
     main(
         jacocoCsvFile = sys.argv[1],
         badgesDirectory = sys.argv[2],

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -204,3 +204,27 @@ if __name__ == "__main__" :
         choices=['true', 'false']
     )
     args = parser.parse_args()
+
+    main(
+        jacocoCsvFile = " ".join(args.csvReports),
+        badgesDirectory = args.badgesDirectory,
+        coverageFilename = args.coverageFilename,
+        branchesFilename = args.branchesFilename,
+        generateCoverageBadge = args.generateCoverageBadge == "true",
+        generateBranchesBadge = args.generateBranchesBadge == "true",
+        onMissingReport = args.onMissingReport,
+        minCoverage = args.minCoverage,
+        minBranches = args.minBranches,
+        failOnCoverageDecrease = args.failOnCoverageDecrease == "true",
+        failOnBranchesDecrease = args.failOnBranchesDecrease == "true",
+        colorCutoffs = args.colorCutoffs,
+        colors = args.colors,
+        generateCoverageJSON = args.generateCoverageJSON == "true",
+        generateBranchesJSON = args.generateBranchesJSON == "true",
+        coverageJSON = args.coverageJSON,
+        branchesJSON = args.branchesJSON,
+        generateSummary = args.generateSummary == "true",
+        summaryFilename = args.summaryFilename,
+        coverageLabel = args.coverageLabel,
+        branchesLabel = args.branchesLabel
+    )

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -1,0 +1,203 @@
+# jacoco-badge-generator: Coverage badges, and pull request coverage checks,
+# from JaCoCo reports in GitHub Actions.
+# 
+# Copyright (c) 2020-2022 Vincent A Cicirello
+# https://www.cicirello.org/
+#
+# MIT License
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import argparse
+from .coverage_badges import stringToPercentage
+from .coverage_badges import main
+
+if __name__ == "__main__" :
+    # Note: This is the entry point when using the
+    # jacoco-badge-generator as a command-line tool,
+    # such as via a build script, locally (and not via
+    # GitHub Actions). The source code for the entry
+    # point for GitHub Actions is found at src/entrypoint.py,
+    # although please see the project README.md for detailed
+    # usage within an GitHub Actions workflow.
+
+    print("jacoco-badge-generator: Generate coverage badges from JaCoCo coverage reports")
+    print("Copyright (C) 2022 Vincent A. Cicirello (https://www.cicirello.org/)")
+    print("MIT License: https://github.com/cicirello/jacoco-badge-generator/blob/main/LICENSE")
+    print()
+
+    parser = argparse.ArgumentParser(
+        prog="jacoco-badge-generator",
+        description="Generate coverage badges from JaCoCo coverage reports. All parameters are optional, provided that the defaults meet your use-case."
+    )
+    parser.add_argument(
+        "-j", "--jacoco-csv-file",
+        nargs='+',
+        default=["target/site/jacoco/jacoco.csv"],
+        help="Filename(s) with full path(s) relative to current working directory of one or more JaCoCo csv reports (default is target/site/jacoco/jacoco.csv).",
+        dest="csvReports",
+        metavar="report_files"
+    )
+    parser.add_argument(
+        "-d", "--badges-directory",
+        default="badges",
+        help="Directory for storing the badges relative to current working directory (default: badges), which will be created if it doesn't exist.",
+        dest="badgesDirectory",
+        metavar="badges-directory"
+    )
+    parser.add_argument(
+        "--generate-coverage-badge",
+        default="true",
+        help="Controls whether to generate the coverage badge (default: true).",
+        dest="generateCoverageBadge",
+        choices=['true', 'false']
+    )
+    parser.add_argument(
+        "--coverage-badge-filename",
+        default="jacoco.svg",
+        help="Filename for the coverage badge (Instructions or C0 Coverage) (default: jacoco.svg), which will be created in the badges directory.",
+        dest="coverageFilename",
+        metavar="coverage-badge-filename"
+    )
+    parser.add_argument(
+        "--generate-branches-badge",
+        default="false",
+        help="Controls whether to generate the branches coverage badge (default: false).",
+        dest="generateBranchesBadge",
+        choices=['true', 'false']
+    )
+    parser.add_argument(
+        "--branches-badge-filename",
+        default="branches.svg",
+        help="Filename for the branches coverage badge (C1 Coverage) (default: branches.svg), which will be created in the badges directory.",
+        dest="branchesFilename",
+        metavar="branches-badge-filename"
+    )
+    parser.add_argument(
+        "--generate-coverage-endpoint",
+        default="false",
+        help="Controls whether to generate a Shields JSON endpoint for coverage (default: false).",
+        dest="generateCoverageJSON",
+        choices=['true', 'false']
+    )
+    parser.add_argument(
+        "--coverage-endpoint-filename",
+        default="jacoco.json",
+        help="Filename for the coverage Shields JSON endpoint (Instructions or C0 Coverage) (default: jacoco.json), which will be created in the badges directory.",
+        dest="coverageJSON",
+        metavar="coverage-endpoint-filename"
+    )
+    parser.add_argument(
+        "--generate-branches-endpoint",
+        default="false",
+        help="Controls whether to generate a Shields JSON endpoint for branches coverage (default: false).",
+        dest="generateBranchesJSON",
+        choices=['true', 'false']
+    )
+    parser.add_argument(
+        "--branches-endpoint-filename",
+        default="branches.json",
+        help="Filename for the branches coverage Shields JSON endpoint (C1 Coverage) (default: branches.json), which will be created in the badges directory.",
+        dest="branchesJSON",
+        metavar="branches-endpoint-filename"
+    )
+    parser.add_argument(
+        "--generate-summary",
+        default="false",
+        help="Controls whether or not to generate a simple JSON summary report of the following form: {\"branches\": 77.77777777777779, \"coverage\": 72.72727272727273}. Default: false.",
+        dest="generateSummary",
+        choices=['true', 'false']
+    )
+    parser.add_argument(
+        "--summary-filename",
+        default="coverage-summary.json",
+        help="Filename for the summary report (see above). Default: coverage-summary.json, and will be created within the badges directory.",
+        dest="summaryFilename",
+        metavar="summary-filename"
+    )
+    parser.add_argument(
+        "--coverage-label",
+        default="coverage",
+        help="Text for the label on the left side of the coverage badge. Default: coverage.",
+        dest="coverageLabel",
+        metavar="coverage-label"
+    )
+    parser.add_argument(
+        "--branches-label",
+        default="branches",
+        help="Text for the label on the left side of the branches coverage badge. Default: branches.",
+        dest="branchesLabel",
+        metavar="branches-label"
+    )
+    parser.add_argument(
+        "--colors",
+        nargs="+",
+        default=["#4c1", "#97ca00", "#a4a61d", "#dfb317", "#fe7d37", "#e05d44"],
+        help="Badge colors in order corresponding to the order of the coverage percentages specified in the --intervals input. Colors can be specified with 6-digit hex, such as #97ca00, or 3-digit hex, such as #4c1, or as SVG named colors, such as green. Default: #4c1 #97ca00 #a4a61d #dfb317 #fe7d37 #e05d44. Depending upon your shell, you may need to escape the # characters or quote each color.",
+        dest="colors",
+        metavar="color"
+    )
+    parser.add_argument(
+        "--intervals",
+        nargs="+",
+        default=[100, 90, 80, 70, 60, 0],
+        help="Percentages in decreasing order that serve as minimum needed for each color. Order corresponds to that of --colors input. Default: 100 90 80 70 60 0, which means coverage of 100 gets first color, at least 90 gets second color, etc.",
+        dest="colorCutoffs",
+        metavar="min-coverage-for-color",
+        type=float
+    )
+    parser.add_argument(
+        "--on-missing-report",
+        default="fail",
+        help="Controls what happens if one or more jacoco.csv files do not exist (fail = output error and return non-zero exit code, quiet = exit silently without generating badges and exit code of 0, badges = generate badges from the csv files present (not recommended)). Default: fail.",
+        dest="onMissingReport",
+        choices=['fail', 'quiet', 'badges']
+    )
+    parser.add_argument(
+        "--fail-if-coverage-less-than",
+        default=0,
+        help="Don't generate badges and return a non-zero exit code if coverage less than a minimum percentage, specified as value between 0.0 and 1.0, or as a percent (with or without the %% sign). E.g., 0.6, 60, and 60%% are all equivalent. Default: 0.",
+        dest="minCoverage",
+        metavar="min-coverage",
+        type=lambda s : stringToPercentage(s)
+    )
+    parser.add_argument(
+        "--fail-if-branches-less-than",
+        default=0,
+        help="Don't generate badges and return a non-zero exit code if branches coverage less than a minimum percentage, specified as value between 0.0 and 1.0, or as a percent (with or without the %% sign). E.g., 0.6, 60, and 60%% are all equivalent. Default: 0.",
+        dest="minBranches",
+        metavar="min-branches",
+        type=lambda s : stringToPercentage(s)
+    )
+    parser.add_argument(
+        "--fail-on-coverage-decrease",
+        default="false",
+        help="If true, will exit with non-zero error code if coverage is less than prior run as recorded in either the existing badge, the existing Shields endpoint, or the JSON summary report (default: false).",
+        dest="failOnCoverageDecrease",
+        choices=['true', 'false']
+    )
+    parser.add_argument(
+        "--fail-on-branches-decrease",
+        default="false",
+        help="If true, will exit with non-zero error code if branches coverage is less than prior run as recorded in either the existing badge, the existing Shields endpoint, or the JSON summary report (default: false).",
+        dest="failOnBranchesDecrease",
+        choices=['true', 'false']
+    )
+    args = parser.parse_args()

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -30,7 +30,10 @@ from .coverage_badges import stringToPercentage
 from .coverage_badges import main
 
 if __name__ == "__main__" :
-    # Note: This is the entry point when using the
+    # IMPORTANT: This is the entrypoint for the use-case of
+    # running as a command-line utility only.
+    #
+    # This is the entry point when using the
     # jacoco-badge-generator as a command-line tool,
     # such as via a build script, locally (and not via
     # GitHub Actions). The source code for the entry

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -53,6 +53,24 @@ class IntegrationTest(unittest.TestCase) :
         with open("tests/custom2.json","r") as expected :
             with open("tests/badges/customBranches.json","r") as generated :
                 self.assertEqual(expected.read(), generated.read())
+
+    def testCLIIntegrationInstructionsBadge(self) :
+        with open("tests/100.svg","r") as expected :
+            with open("tests/cli/badges/jacoco.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
+    def testCLIIntegrationBranchesBadge(self) :
+        with open("tests/90b.svg","r") as expected :
+            with open("tests/cli/badges/branches.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
+    def testCLIIntegrationMultiJacocoReportsCase(self) :
+        with open("tests/78.svg","r") as expected :
+            with open("tests/cli/badges/coverageMulti.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+        with open("tests/87b.svg","r") as expected :
+            with open("tests/cli/badges/branchesMulti.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
                 
     def testIntegrationInstructionsBadge(self) :
         with open("tests/100.svg","r") as expected :

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -95,6 +95,12 @@ class IntegrationTest(unittest.TestCase) :
             d = json.load(f)
             self.assertAlmostEqual(72.72727272727272, d["coverage"])
             self.assertAlmostEqual(77.77777777777777, d["branches"])
+    
+    def testCLIIntegrationSummaryReport(self) :
+        with open("tests/cli/summary/coverage-summary.json", "r") as f :
+            d = json.load(f)
+            self.assertAlmostEqual(72.72727272727272, d["coverage"])
+            self.assertAlmostEqual(77.77777777777777, d["branches"])
 
     def testIntegrationInstructionsJSON(self) :
         with open("tests/endpoints/jacoco.json", "r") as f :

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -34,6 +34,26 @@ import jacoco_badge_generator.coverage_badges as jbg
 
 class IntegrationTest(unittest.TestCase) :
 
+    def testCLIIntegrationCustomCoverageLabel(self) :
+        with open("tests/custom1.svg","r") as expected :
+            with open("tests/cli/badges/customCoverage.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
+    def testCLIIntegrationCustomBranchesLabel(self) :
+        with open("tests/custom2.svg","r") as expected :
+            with open("tests/cli/badges/customBranches.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
+    def testCLIIntegrationCustomCoverageLabelJSON(self) :
+        with open("tests/custom1.json","r") as expected :
+            with open("tests/cli/badges/customCoverage.json","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
+    def testCLIIntegrationCustomBranchesLabelJSON(self) :
+        with open("tests/custom2.json","r") as expected :
+            with open("tests/cli/badges/customBranches.json","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
     def testIntegrationCustomCoverageLabel(self) :
         with open("tests/custom1.svg","r") as expected :
             with open("tests/badges/customCoverage.svg","r") as generated :

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -111,4 +111,20 @@ class IntegrationTest(unittest.TestCase) :
             self.assertEqual("branches", d["label"])
             self.assertEqual("90%", d["message"])
             self.assertEqual(jbg.defaultColors[1], d["color"])
+
+    def testCLIIntegrationInstructionsJSON(self) :
+        with open("tests/cli/badgesJSON/jacoco.json", "r") as f :
+            d = json.load(f)
+            self.assertEqual(1, d["schemaVersion"])
+            self.assertEqual("coverage", d["label"])
+            self.assertEqual("100%", d["message"])
+            self.assertEqual(jbg.defaultColors[0], d["color"])
+
+    def testCLIIntegrationBranchesJSON(self) :
+        with open("tests/cli/badgesJSON/branches.json", "r") as f :
+            d = json.load(f)
+            self.assertEqual(1, d["schemaVersion"])
+            self.assertEqual("branches", d["label"])
+            self.assertEqual("90%", d["message"])
+            self.assertEqual(jbg.defaultColors[1], d["color"])
     


### PR DESCRIPTION
## Summary
Added an alternate entry point for running as CLI utility, specifically via the __main__.py. Thus, running as command line utility outside of GitHub Actions, such as in a local build script, involves running the module with the -m flag.

## Closing Issues
Closes #65 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

##  NOTE
Deliberately didn't edit documentation to document this new functionality yet. Leaving #40 open for this reason. Need to simplify process for installing as a command-line utility first.