### PR TITLE
Replaced use of GitHub Action's deprecated set-output workflow command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-07
+## [Unreleased] - 2022-10-21
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Replaced use of GitHub Action's deprecated `set-output` workflow command.
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.6.0 to 4.11.0, which includes upgrading Python within the Docker container to 3.10.7.

--- a/src/jacoco_badge_generator/coverage_badges.py
+++ b/src/jacoco_badge_generator/coverage_badges.py
@@ -458,6 +458,22 @@ def coverageDictionary(cov, branches) :
     """
     return { "coverage" : 100 * cov, "branches" : 100 * branches }
 
+def set_action_outputs(output_pairs) :
+    """Sets the GitHub Action outputs if running as a GitHub Action,
+    and otherwise logs coverage percentages to terminal if running in
+    CLI mode.
+
+    Keyword arguments:
+    output_pairs - Dictionary of outputs with values
+    """
+    if "GITHUB_OUTPUT" in os.environ :
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f :
+            for key, value in output_pairs.items() :
+                print("{0}={1}".format(key, value), file=f)
+    else :
+        for key, value in output_pairs.items() :
+            print("{0}={1}".format(key, value))
+
 def main(jacocoCsvFile,
          badgesDirectory,
          coverageFilename,
@@ -594,5 +610,4 @@ def main(jacocoCsvFile,
             with open(summaryFilenameWithPath, "w") as summaryFile :
                 json.dump(coverageDictionary(cov, branches), summaryFile, sort_keys=True)
 
-        print("::set-output name=coverage::" + str(cov))
-        print("::set-output name=branches::" + str(branches))
+        set_action_outputs({"coverage" : cov, "branches" : branches})


### PR DESCRIPTION
## Summary
Replaced use of GitHub Action's deprecated `set-output` workflow command.

## Closing Issues
Fixes #84 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
