### PR TITLE
Fallback to `set-output` if `$GITHUB_OUTPUT`  doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-21
+## [Unreleased] - 2022-10-24
 
 ### Added
 
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bump cicirello/pyaction from 4.11.0 to 4.11.1
 
 ### CI/CD
+
+
+## [2.8.1] - 2022-10-24
+
+### Fixed
+* The replacement for GitHub Action's deprecated `set-output` is not available yet for all self-hosted users. This patch
+  handles that by using the new `$GITHUB_OUTPUT` environment file if it exists, and otherwise falling back to `set-output`.
+
+### Dependencies
+* Bump cicirello/pyaction from 4.11.0 to 4.11.1
 
 
 ## [2.8.0] - 2022-10-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Dependencies
-* Bump cicirello/pyaction from 4.11.0 to 4.11.1
 
 ### CI/CD
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jacoco-badge-generator"
-version = "2.8.0"
+version = "2.8.1"
 authors = [
   { name="Vincent A. Cicirello", email="development@cicirello.org" },
 ]

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -62,5 +62,6 @@ if __name__ == "__main__" :
         generateSummary = sys.argv[18].lower() == "true",
         summaryFilename = sys.argv[19],
         coverageLabel = sys.argv[20],
-        branchesLabel = sys.argv[21]
+        branchesLabel = sys.argv[21],
+        ghActionsMode = True
     )

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -226,5 +226,6 @@ if __name__ == "__main__" :
         generateSummary = args.generateSummary == "true",
         summaryFilename = args.summaryFilename,
         coverageLabel = args.coverageLabel,
-        branchesLabel = args.branchesLabel
+        branchesLabel = args.branchesLabel,
+        ghActionsMode = False
     )


### PR DESCRIPTION
## Summary
The replacement for GitHub Action's deprecated `set-output` is not available yet for all self-hosted users. This patch handles that by using the new `$GITHUB_OUTPUT` environment file if it exists, and otherwise falling back to the deprecated `set-output`.

## Closing Issues
Closes #90 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
