### PR TITLE
Support glob patterns for specifying multiple jacoco reports for multimodule projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,21 @@ jobs:
         echo "coverage = ${{ steps.integration5.outputs.coverage }}"
         echo "branch coverage = ${{ steps.integration5.outputs.branches }}"
 
+    - name: Integration test with multiple csv files with glob
+      id: integration6
+      uses: ./
+      with:
+        jacoco-csv-file: **/multi*.csv
+        badges-directory: tests/glob/badges
+        generate-branches-badge: true
+        coverage-badge-filename: coverageMulti.svg
+        branches-badge-filename: branchesMulti.svg
+
+    - name: Log integration test outputs with multiple csv files with glob
+      run: |
+        echo "coverage = ${{ steps.integration6.outputs.coverage }}"
+        echo "branch coverage = ${{ steps.integration6.outputs.branches }}"
+
     - name: Integration test of CLI use-case
       id: integrationCLI
       run: |
@@ -120,6 +135,7 @@ jobs:
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badgesJSON --generate-coverage-badge false --generate-coverage-endpoint true --generate-branches-endpoint true
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/summaryReportTest.csv --badges-directory tests/cli/summary --generate-coverage-badge false --generate-summary true
         python3 -B -m jacoco_badge_generator --jacoco-csv-file tests/jacoco.csv --badges-directory tests/cli/badges --generate-branches-badge true --generate-coverage-endpoint true --generate-branches-endpoint true --coverage-badge-filename customCoverage.svg --branches-badge-filename customBranches.svg --coverage-endpoint-filename customCoverage.json --branches-endpoint-filename customBranches.json --coverage-label "custom coverage label one" --branches-label "custom coverage label two"
+        python3 -B -m jacoco_badge_generator --jacoco-csv-file **/multi*.csv --badges-directory tests/glob/badges --generate-branches-badge true --coverage-badge-filename coverageMultiCLI.svg --branches-badge-filename branchesMultiCLI.svg
 
     - name: Verify integration test results
       run: python3 -u -m unittest tests/integration.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       id: integration6
       uses: ./
       with:
-        jacoco-csv-file: **/multi*.csv
+        jacoco-csv-file: "**/multi*.csv"
         badges-directory: tests/glob/badges
         generate-branches-badge: true
         coverage-badge-filename: coverageMulti.svg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-05-12
+## [Unreleased] - 2023-05-24
 
 ### Added
+* Support for glob patterns to specify multiple jacoco reports for multimodule projects.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2023-05-24
 
 ### Added
-* Support for glob patterns to specify multiple jacoco reports for multimodule projects.
+* Support for glob patterns in GitHub Actions mode for specifying multiple JaCoCo reports for multi-module projects (note: CLI mode already supported this indirectly since the shell expands globs automatically).
 
 ### Changed
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -3,7 +3,7 @@
 # jacoco-badge-generator: Coverage badges, and pull request coverage checks,
 # from JaCoCo reports in GitHub Actions.
 # 
-# Copyright (c) 2020-2022 Vincent A Cicirello
+# Copyright (c) 2020-2023 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License

--- a/src/jacoco_badge_generator/__init__.py
+++ b/src/jacoco_badge_generator/__init__.py
@@ -1,7 +1,7 @@
 # jacoco-badge-generator: Coverage badges, and pull request coverage checks,
 # from JaCoCo reports in GitHub Actions.
 # 
-# Copyright (c) 2020-2022 Vincent A Cicirello
+# Copyright (c) 2020-2023 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -1,7 +1,7 @@
 # jacoco-badge-generator: Coverage badges, and pull request coverage checks,
 # from JaCoCo reports in GitHub Actions.
 # 
-# Copyright (c) 2020-2022 Vincent A Cicirello
+# Copyright (c) 2020-2023 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -42,7 +42,7 @@ if __name__ == "__main__" :
     # usage within an GitHub Actions workflow.
 
     print("jacoco-badge-generator: Generate coverage badges from JaCoCo coverage reports")
-    print("Copyright (C) 2022 Vincent A. Cicirello (https://www.cicirello.org/)")
+    print("Copyright (C) 2022-2023 Vincent A. Cicirello (https://www.cicirello.org/)")
     print("MIT License: https://github.com/cicirello/jacoco-badge-generator/blob/main/LICENSE")
     print()
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1,7 +1,7 @@
 # jacoco-badge-generator: Github action for generating a jacoco coverage
 # percentage badge.
 # 
-# Copyright (c) 2020-2022 Vincent A Cicirello
+# Copyright (c) 2020-2023 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -33,6 +33,22 @@ sys.path.insert(0,'src')
 import jacoco_badge_generator.coverage_badges as jbg
 
 class IntegrationTest(unittest.TestCase) :
+
+    def testCLIGLOBIntegrationMultiJacocoReportsCase(self) :
+        with open("tests/78.svg","r") as expected :
+            with open("tests/glob/badges/coverageMultiCLI.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+        with open("tests/87b.svg","r") as expected :
+            with open("tests/glob/badges/branchesMultiCLI.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+
+    def testGLOBIntegrationMultiJacocoReportsCase(self) :
+        with open("tests/78.svg","r") as expected :
+            with open("tests/glob/badges/coverageMulti.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
+        with open("tests/87b.svg","r") as expected :
+            with open("tests/glob/badges/branchesMulti.svg","r") as generated :
+                self.assertEqual(expected.read(), generated.read())
 
     def testCLIIntegrationCustomCoverageLabel(self) :
         with open("tests/custom1.svg","r") as expected :

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 # jacoco-badge-generator: Github action for generating a jacoco coverage
 # percentage badge.
 # 
-# Copyright (c) 2020-2022 Vincent A Cicirello
+# Copyright (c) 2020-2023 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -421,7 +421,8 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
         self.assertAlmostEqual(0, jbg.stringToPercentage("hello"))
 
     def testFilterMissingReports_empty(self) :
-        self.assertEqual([], jbg.filterMissingReports([]))
+        self.assertEqual(([], False), jbg.filterMissingReports([]))
+        self.assertEqual(([], True), jbg.filterMissingReports(["**/idontexist*.csv"]))
 
     def testFilterMissingReports(self) :
         expected = ["tests/jacoco100.csv", "tests/jacoco90.csv"]
@@ -431,7 +432,19 @@ class TestJacocoBadgeGenerator(unittest.TestCase) :
                 "tests/idontexist3.csv",
                 "tests/jacoco90.csv",
                 "tests/idontexist4.csv"]
-        self.assertEqual(expected, jbg.filterMissingReports(case))
+        self.assertEqual((expected, True), jbg.filterMissingReports(case))
+
+    def testFilterMissingReports_withGlobs(self) :
+        expected = {
+            "tests/jacoco.csv",
+            "tests/jacoco90.csv",
+            "tests/jacoco100.csv",
+            "tests/jacoco901.csv",
+            "tests/jacocoDivZero.csv" }
+        case = ["**/j*.csv"]
+        reports, isMissing = jbg.filterMissingReports(case)
+        actual = { s.replace("\\", "/") for s in reports }
+        self.assertEqual((expected, False), (actual, isMissing))
         
     def testFullCoverage(self) :
         self.assertAlmostEqual(1, jbg.computeCoverage(["tests/jacoco100.csv"])[0])


### PR DESCRIPTION
## Summary
Added support for using glob patterns to specify multiple jacoco report files for multimodule projects. Note that documentation will be updated at the time this feature is released, and README deliberately not updated yet (e.g., GitHub automatically propagates README changes to the Action's page in Marketplace regardless of whether a new release is created).

## Closing Issues
Closes #112 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
