### PR TITLE
add input variable for generating workflow summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-08-29
+## [Unreleased] - 2023-09-03
 
 ### Added
+* Option to suppress workflow job summary in GitHub Actions Mode.
 
 ### Changed
 

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,10 @@ inputs:
     description: 'The filename of the summary file.'
     required: false
     default: 'coverage-summary.json'
+  generate-workflow-summary:
+    description: 'Controls whether or not to append markdown summary to the GitHub Workflow Summary page.'
+    required: false
+    default: true
 outputs:
   coverage:
     description: 'The jacoco coverage percentage as computed from the data in the jacoco.csv file.'
@@ -144,5 +148,6 @@ runs:
     - ${{ inputs.branches-endpoint-filename }}
     - ${{ inputs.generate-summary }}
     - ${{ inputs.summary-filename }}
+    - ${{ inputs.generate-workflow-summary }}
     - ${{ inputs.coverage-label }}
     - ${{ inputs.branches-label }}

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -61,7 +61,8 @@ if __name__ == "__main__" :
         branchesJSON = sys.argv[17],
         generateSummary = sys.argv[18].lower() == "true",
         summaryFilename = sys.argv[19],
-        coverageLabel = sys.argv[20],
-        branchesLabel = sys.argv[21],
+        appendWorkflowSummary = sys.argv[20].lower() == "true",
+        coverageLabel = sys.argv[21],
+        branchesLabel = sys.argv[22],
         ghActionsMode = True
     )

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -203,13 +203,6 @@ if __name__ == "__main__" :
         dest="failOnBranchesDecrease",
         choices=['true', 'false']
     )
-    parser.add_argument(
-        "--append-workflow-summary",
-        default="true",
-        help="If true, will append the coverage summary to the workflow summary (default: true).",
-        dest="appendWorkflowSummary",
-        choices=['true', 'false']
-    )
     args = parser.parse_args()
 
     main(
@@ -232,7 +225,7 @@ if __name__ == "__main__" :
         branchesJSON = args.branchesJSON,
         generateSummary = args.generateSummary == "true",
         summaryFilename = args.summaryFilename,
-        appendWorkflowSummary = args.appendWorkflowSummary == "true",
+        appendWorkflowSummary = False,
         coverageLabel = args.coverageLabel,
         branchesLabel = args.branchesLabel,
         ghActionsMode = False

--- a/src/jacoco_badge_generator/__main__.py
+++ b/src/jacoco_badge_generator/__main__.py
@@ -203,6 +203,13 @@ if __name__ == "__main__" :
         dest="failOnBranchesDecrease",
         choices=['true', 'false']
     )
+    parser.add_argument(
+        "--append-workflow-summary",
+        default="true",
+        help="If true, will append the coverage summary to the workflow summary (default: true).",
+        dest="appendWorkflowSummary",
+        choices=['true', 'false']
+    )
     args = parser.parse_args()
 
     main(
@@ -225,6 +232,7 @@ if __name__ == "__main__" :
         branchesJSON = args.branchesJSON,
         generateSummary = args.generateSummary == "true",
         summaryFilename = args.summaryFilename,
+        appendWorkflowSummary = args.appendWorkflowSummary == "true",
         coverageLabel = args.coverageLabel,
         branchesLabel = args.branchesLabel,
         ghActionsMode = False

--- a/src/jacoco_badge_generator/coverage_badges.py
+++ b/src/jacoco_badge_generator/coverage_badges.py
@@ -567,6 +567,8 @@ def main(jacocoCsvFile,
     generateSummary - Boolean to control whether or not to generate a JSON file
         containing the coverage percentages as floating-point values.
     summaryFilename - The filename of the summary file.
+    appendWorkflowSummary - If True and if running in GitHub Actions, logs coverage
+        percentages to workflow job summary.
     coverageLabel - Text for the left-side of the coverage badge.
     branchesLabel - Text for the left-side of the branches coverage badge.
     ghActionsMode - True if running in GitHub Actions mode, or False otherwise.

--- a/src/jacoco_badge_generator/coverage_badges.py
+++ b/src/jacoco_badge_generator/coverage_badges.py
@@ -526,6 +526,7 @@ def main(jacocoCsvFile,
          branchesJSON,
          generateSummary,
          summaryFilename,
+         appendWorkflowSummary,
          coverageLabel,
          branchesLabel,
          ghActionsMode) :
@@ -649,4 +650,7 @@ def main(jacocoCsvFile,
             {"coverage" : cov, "branches" : branches},
             ghActionsMode
         )
-        add_workflow_job_summary(cov, branches)
+
+        if appendWorkflowSummary :
+            add_workflow_job_summary(cov, branches)
+        


### PR DESCRIPTION
## Summary
Add input variable to enable suppressing the logging of coverage to workflow job summary.

## Closing Issues
Closes #127 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
