### PR TITLE
updated to new tag format for base docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-05-20
+## [Unreleased] - 2025-07-11
 
 ### Added
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Dependencies
+* Updated Docker file to use new tag format for `cicirello/pyaction`
 
 ### CI/CD
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2020-2025 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM ghcr.io/cicirello/pyaction:4.33.0
+FROM ghcr.io/cicirello/pyaction:3.13.5-gh-2.75.0
 COPY src /
 ENTRYPOINT ["/entrypoint.py"]


### PR DESCRIPTION
## Summary
Updated to new tag format for base docker image. The pyaction Docker image changed tag format to explicitly specify Python version and GitHub CLI version. In this case, the tag `3.13.5-gh-2.75.0` means Python 3.13.5 and GitHub CLI 2.75.0. This change doesn't impact functionality or usage of the action, although it does correspond to updating the patch level Python release and to a new minor release of the GitHub CLI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
